### PR TITLE
채팅 메시지에 블로그 게시글 url 공유 기능 추가

### DIFF
--- a/prisma/migrations/20250204044808_add_blog_url_field_to_chat_message/migration.sql
+++ b/prisma/migrations/20250204044808_add_blog_url_field_to_chat_message/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "chat_messages" ADD COLUMN     "blog_url" VARCHAR(1000);

--- a/prisma/migrations/20250204112229_modify_blog_post_url_name_and_length/migration.sql
+++ b/prisma/migrations/20250204112229_modify_blog_post_url_name_and_length/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `blog_url` on the `chat_messages` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "chat_messages" DROP COLUMN "blog_url",
+ADD COLUMN     "blog_post_url" VARCHAR(255);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,14 +100,14 @@ model ChatRoom {
 }
 
 model ChatMessage {
-  id        BigInt    @id(map: "pk_chat_messages")
-  roomId    BigInt    @map("room_id") @db.BigInt()
-  senderId  BigInt    @map("sender_id") @db.BigInt()
-  message   String    @db.VarChar(1000)
-  blogUrl   String?   @map("blog_url") @db.VarChar(1000)
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt DateTime  @default(now()) @map("updated_at") @db.Timestamptz(6)
-  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6)
+  id          BigInt    @id(map: "pk_chat_messages")
+  roomId      BigInt    @map("room_id") @db.BigInt()
+  senderId    BigInt    @map("sender_id") @db.BigInt()
+  message     String    @db.VarChar(1000)
+  blogPostUrl String?   @map("blog_post_url") @db.VarChar(255)
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime  @default(now()) @map("updated_at") @db.Timestamptz(6)
+  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz(6)
 
   chatRoom ChatRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
   sender   User     @relation(fields: [senderId], references: [id], onDelete: Cascade)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,7 @@ model ChatMessage {
   roomId    BigInt    @map("room_id") @db.BigInt()
   senderId  BigInt    @map("sender_id") @db.BigInt()
   message   String    @db.VarChar(1000)
+  blogUrl   String?   @map("blog_url") @db.VarChar(1000)
   createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt DateTime  @default(now()) @map("updated_at") @db.Timestamptz(6)
   deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6)

--- a/src/features/chat-message/commands/create-message/create-chat-message.command-handler.ts
+++ b/src/features/chat-message/commands/create-message/create-chat-message.command-handler.ts
@@ -24,7 +24,7 @@ export class CreateChatMessageCommandHandler
   ) {}
 
   async execute(command: CreateChatMessageCommand): Promise<void> {
-    const { roomId, userId, message, blogUrl } = command;
+    const { roomId, userId, message, blogPostUrl } = command;
 
     const chatRoom = await this.chatRoomRepository.findOneById(roomId);
 
@@ -57,7 +57,7 @@ export class CreateChatMessageCommandHandler
       roomId,
       senderId: userId,
       message,
-      blogUrl,
+      blogPostUrl,
     });
 
     await this.chatRoomRepository.createChatMessage(chatMessage);

--- a/src/features/chat-message/commands/create-message/create-chat-message.command-handler.ts
+++ b/src/features/chat-message/commands/create-message/create-chat-message.command-handler.ts
@@ -24,7 +24,7 @@ export class CreateChatMessageCommandHandler
   ) {}
 
   async execute(command: CreateChatMessageCommand): Promise<void> {
-    const { roomId, userId, message } = command;
+    const { roomId, userId, message, blogUrl } = command;
 
     const chatRoom = await this.chatRoomRepository.findOneById(roomId);
 
@@ -57,6 +57,7 @@ export class CreateChatMessageCommandHandler
       roomId,
       senderId: userId,
       message,
+      blogUrl,
     });
 
     await this.chatRoomRepository.createChatMessage(chatMessage);

--- a/src/features/chat-message/commands/create-message/create-chat-message.command.ts
+++ b/src/features/chat-message/commands/create-message/create-chat-message.command.ts
@@ -6,12 +6,12 @@ export class CreateChatMessageCommand implements ICommand {
   readonly userId: AggregateID;
   readonly roomId: AggregateID;
   readonly message: string;
-  readonly blogUrl: string | null;
+  readonly blogPostUrl: string | null;
 
   constructor(props: CommandProps<CreateChatMessageCommand>) {
     this.userId = props.userId;
     this.roomId = props.roomId;
     this.message = props.message;
-    this.blogUrl = props.blogUrl;
+    this.blogPostUrl = props.blogPostUrl;
   }
 }

--- a/src/features/chat-message/commands/create-message/create-chat-message.command.ts
+++ b/src/features/chat-message/commands/create-message/create-chat-message.command.ts
@@ -6,10 +6,12 @@ export class CreateChatMessageCommand implements ICommand {
   readonly userId: AggregateID;
   readonly roomId: AggregateID;
   readonly message: string;
+  readonly blogUrl: string | null;
 
   constructor(props: CommandProps<CreateChatMessageCommand>) {
     this.userId = props.userId;
     this.roomId = props.roomId;
     this.message = props.message;
+    this.blogUrl = props.blogUrl;
   }
 }

--- a/src/features/chat-message/domain/chat-message.entity-interface.ts
+++ b/src/features/chat-message/domain/chat-message.entity-interface.ts
@@ -4,7 +4,7 @@ export interface ChatMessageProps {
   roomId: AggregateID;
   senderId: AggregateID;
   message: string;
-  blogUrl: string | null;
+  blogPostUrl: string | null;
   deletedAt: Date | null;
 }
 
@@ -12,5 +12,5 @@ export interface CreateChatMessageProps {
   roomId: AggregateID;
   senderId: AggregateID;
   message: string;
-  blogUrl: string | null;
+  blogPostUrl: string | null;
 }

--- a/src/features/chat-message/domain/chat-message.entity-interface.ts
+++ b/src/features/chat-message/domain/chat-message.entity-interface.ts
@@ -4,6 +4,7 @@ export interface ChatMessageProps {
   roomId: AggregateID;
   senderId: AggregateID;
   message: string;
+  blogUrl: string | null;
   deletedAt: Date | null;
 }
 
@@ -11,4 +12,5 @@ export interface CreateChatMessageProps {
   roomId: AggregateID;
   senderId: AggregateID;
   message: string;
+  blogUrl: string | null;
 }

--- a/src/features/chat-message/dtos/request/find-chat-messages.request-query-dto.ts
+++ b/src/features/chat-message/dtos/request/find-chat-messages.request-query-dto.ts
@@ -18,7 +18,6 @@ export class FindChatMessagesRequestQueryDto extends CursorPaginationRequestQuer
     },
     createdAt: {
       type: 'date',
-      required: true,
     },
     updatedAt: {
       type: 'date',

--- a/src/features/chat-message/dtos/response/chat-message.response-dto.ts
+++ b/src/features/chat-message/dtos/response/chat-message.response-dto.ts
@@ -38,6 +38,7 @@ export class ChatMessageResponseDto
   @ApiProperty({
     example: 'https://honeymoa.com/blog/2',
     description: '블로그 게시글 URL',
+    nullable: true,
   })
   readonly blogUrl: string | null;
 

--- a/src/features/chat-message/dtos/response/chat-message.response-dto.ts
+++ b/src/features/chat-message/dtos/response/chat-message.response-dto.ts
@@ -10,6 +10,7 @@ export interface CreateChatMessageResponseDtoProps
   roomId: AggregateID;
   senderId: AggregateID;
   message: string;
+  blogUrl: string | null;
 }
 
 export class ChatMessageResponseDto
@@ -34,13 +35,20 @@ export class ChatMessageResponseDto
   })
   readonly message: string;
 
+  @ApiProperty({
+    example: 'https://honeymoa.com/blog/2',
+    description: '블로그 게시글 URL',
+  })
+  readonly blogUrl: string | null;
+
   constructor(create: CreateChatMessageResponseDtoProps) {
     super(create);
 
-    const { roomId, senderId, message } = create;
+    const { roomId, senderId, message, blogUrl } = create;
 
     this.roomId = roomId;
     this.senderId = senderId;
     this.message = message;
+    this.blogUrl = blogUrl;
   }
 }

--- a/src/features/chat-message/dtos/response/chat-message.response-dto.ts
+++ b/src/features/chat-message/dtos/response/chat-message.response-dto.ts
@@ -10,7 +10,7 @@ export interface CreateChatMessageResponseDtoProps
   roomId: AggregateID;
   senderId: AggregateID;
   message: string;
-  blogUrl: string | null;
+  blogPostUrl: string | null;
 }
 
 export class ChatMessageResponseDto
@@ -40,16 +40,16 @@ export class ChatMessageResponseDto
     description: '블로그 게시글 URL',
     nullable: true,
   })
-  readonly blogUrl: string | null;
+  readonly blogPostUrl: string | null;
 
   constructor(create: CreateChatMessageResponseDtoProps) {
     super(create);
 
-    const { roomId, senderId, message, blogUrl } = create;
+    const { roomId, senderId, message, blogPostUrl } = create;
 
     this.roomId = roomId;
     this.senderId = senderId;
     this.message = message;
-    this.blogUrl = blogUrl;
+    this.blogPostUrl = blogPostUrl;
   }
 }

--- a/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
+++ b/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
@@ -32,5 +32,5 @@ export class CreateChatMessageDto {
   @IsNullable()
   @IsUrl()
   @Length(1, 1000)
-  blogUrl: string | null = null;
+  blogPostUrl: string | null = null;
 }

--- a/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
+++ b/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
@@ -1,7 +1,8 @@
 import { IsBigIntString } from '@libs/api/decorators/is-big-int.decorator';
+import { IsNullable } from '@libs/api/decorators/is-nullable.decorator';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUrl, Length } from 'class-validator';
+import { IsString, IsUrl, Length } from 'class-validator';
 
 export class CreateChatMessageDto {
   @ApiProperty({
@@ -22,10 +23,14 @@ export class CreateChatMessageDto {
   message: string;
 
   @ApiProperty({
-    description: '블로그 URL',
+    description: '블로그 게시글 URL',
     example: 'https://honeymoa.com/blog/2',
+    default: null,
+    minLength: 1,
+    maxLength: 1000,
   })
-  @IsOptional()
+  @IsNullable()
   @IsUrl()
-  blogUrl?: string;
+  @Length(1, 1000)
+  blogUrl: string | null = null;
 }

--- a/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
+++ b/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
@@ -1,7 +1,7 @@
 import { IsBigIntString } from '@libs/api/decorators/is-big-int.decorator';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, Length } from 'class-validator';
+import { IsOptional, IsString, IsUrl, Length } from 'class-validator';
 
 export class CreateChatMessageDto {
   @ApiProperty({
@@ -20,4 +20,12 @@ export class CreateChatMessageDto {
   @IsString()
   @Length(1, 1000)
   message: string;
+
+  @ApiProperty({
+    description: '블로그 URL',
+    example: 'https://honeymoa.com/blog/2',
+  })
+  @IsOptional()
+  @IsUrl()
+  blogUrl?: string;
 }

--- a/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
+++ b/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
@@ -1,7 +1,7 @@
 import { IsBigIntString } from '@libs/api/decorators/is-big-int.decorator';
 import { IsNullable } from '@libs/api/decorators/is-nullable.decorator';
 import { AggregateID } from '@libs/ddd/entity.base';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsUrl, Length } from 'class-validator';
 
 export class CreateChatMessageDto {
@@ -22,7 +22,7 @@ export class CreateChatMessageDto {
   @Length(1, 1000)
   message: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: '블로그 게시글 URL',
     example: 'https://honeymoa.com/blog/2',
     default: null,

--- a/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
+++ b/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
@@ -27,10 +27,10 @@ export class CreateChatMessageDto {
     example: 'https://honeymoa.com/blog/2',
     default: null,
     minLength: 1,
-    maxLength: 1000,
+    maxLength: 255,
   })
   @IsNullable()
   @IsUrl()
-  @Length(1, 1000)
+  @Length(1, 255)
   blogPostUrl: string | null = null;
 }

--- a/src/features/chat-message/gateways/chat-message.gateway.ts
+++ b/src/features/chat-message/gateways/chat-message.gateway.ts
@@ -107,7 +107,7 @@ export class ChatMessageGateway implements OnGatewayConnection {
      * (event를 발생시켜서 chatMessage 테이블에 저장하는 방식으로 개선하면 좋을듯.)
      */
 
-    const { roomId, message } = data;
+    const { roomId, message, blogUrl } = data;
     const { sub: userId } = socket.user;
 
     const command = new CreateChatMessageCommand({
@@ -118,6 +118,6 @@ export class ChatMessageGateway implements OnGatewayConnection {
 
     await this.commandBus.execute<CreateChatMessageCommand, void>(command);
 
-    socket.to(String(roomId)).emit('receive_message', message);
+    socket.to(String(roomId)).emit('receive_message', { message, blogUrl });
   }
 }

--- a/src/features/chat-message/gateways/chat-message.gateway.ts
+++ b/src/features/chat-message/gateways/chat-message.gateway.ts
@@ -114,6 +114,7 @@ export class ChatMessageGateway implements OnGatewayConnection {
       roomId: BigInt(roomId),
       userId: BigInt(userId),
       message,
+      blogUrl,
     });
 
     await this.commandBus.execute<CreateChatMessageCommand, void>(command);

--- a/src/features/chat-message/gateways/chat-message.gateway.ts
+++ b/src/features/chat-message/gateways/chat-message.gateway.ts
@@ -107,18 +107,18 @@ export class ChatMessageGateway implements OnGatewayConnection {
      * (event를 발생시켜서 chatMessage 테이블에 저장하는 방식으로 개선하면 좋을듯.)
      */
 
-    const { roomId, message, blogUrl } = data;
+    const { roomId, message, blogPostUrl } = data;
     const { sub: userId } = socket.user;
 
     const command = new CreateChatMessageCommand({
       roomId: BigInt(roomId),
       userId: BigInt(userId),
       message,
-      blogUrl,
+      blogPostUrl,
     });
 
     await this.commandBus.execute<CreateChatMessageCommand, void>(command);
 
-    socket.to(String(roomId)).emit('receive_message', { message, blogUrl });
+    socket.to(String(roomId)).emit('receive_message', { message, blogPostUrl });
   }
 }

--- a/src/features/chat-message/mappers/chat-message.mapper.ts
+++ b/src/features/chat-message/mappers/chat-message.mapper.ts
@@ -12,6 +12,7 @@ export const chatMessageSchema = baseSchema.extend({
   roomId: z.bigint(),
   senderId: z.bigint(),
   message: z.string().max(1000),
+  blogUrl: z.string().max(1000).nullable(),
   deletedAt: z.preprocess(
     (val: any) => (val === null ? null : new Date(val)),
     z.nullable(z.date()),
@@ -32,6 +33,7 @@ export class ChatMessageMapper
         roomId: record.roomId,
         senderId: record.senderId,
         message: record.message,
+        blogUrl: record.blogUrl,
         deletedAt: record.deletedAt,
       },
       createdAt: record.createdAt,

--- a/src/features/chat-message/mappers/chat-message.mapper.ts
+++ b/src/features/chat-message/mappers/chat-message.mapper.ts
@@ -12,7 +12,7 @@ export const chatMessageSchema = baseSchema.extend({
   roomId: z.bigint(),
   senderId: z.bigint(),
   message: z.string().max(1000),
-  blogPostUrl: z.string().max(1000).nullable(),
+  blogPostUrl: z.string().max(255).nullable(),
   deletedAt: z.preprocess(
     (val: any) => (val === null ? null : new Date(val)),
     z.nullable(z.date()),

--- a/src/features/chat-message/mappers/chat-message.mapper.ts
+++ b/src/features/chat-message/mappers/chat-message.mapper.ts
@@ -12,7 +12,7 @@ export const chatMessageSchema = baseSchema.extend({
   roomId: z.bigint(),
   senderId: z.bigint(),
   message: z.string().max(1000),
-  blogUrl: z.string().max(1000).nullable(),
+  blogPostUrl: z.string().max(1000).nullable(),
   deletedAt: z.preprocess(
     (val: any) => (val === null ? null : new Date(val)),
     z.nullable(z.date()),
@@ -33,7 +33,7 @@ export class ChatMessageMapper
         roomId: record.roomId,
         senderId: record.senderId,
         message: record.message,
-        blogUrl: record.blogUrl,
+        blogPostUrl: record.blogPostUrl,
         deletedAt: record.deletedAt,
       },
       createdAt: record.createdAt,

--- a/src/features/chat-message/queries/find-chat-messages/find-chat-messages.query-handler.ts
+++ b/src/features/chat-message/queries/find-chat-messages/find-chat-messages.query-handler.ts
@@ -66,17 +66,21 @@ export class FindChatMessagesQueryHandler
 
     const [chatMessages, count] = await Promise.all([
       this.txHost.tx.chatMessage.findMany({
-        ...(cursor?.id && {
-          cursor: {
-            id: cursor?.id,
-            createdAt: cursor?.createdAt,
-            ...(cursor?.updatedAt && { updatedAt: cursor?.updatedAt }),
-          },
-        }),
+        cursor: cursor ? { id: cursor.id } : undefined,
         where: {
           roomId,
         },
-        orderBy,
+        orderBy: [
+          {
+            id: orderBy?.id,
+          },
+          {
+            createdAt: orderBy?.createdAt,
+          },
+          {
+            updatedAt: orderBy?.updatedAt,
+          },
+        ],
         skip,
         take,
       }),
@@ -85,7 +89,7 @@ export class FindChatMessagesQueryHandler
         where: {
           roomId,
         },
-        cursor: { id: cursor?.id },
+        cursor: cursor ? { id: cursor.id } : undefined,
       }),
     ]);
 


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#99 

<!-- 내용 (필수) -->

### Description

채팅 메시지에 블로그 게시글 url 공유 기능 추가
<img width="473" alt="스크린샷 2025-02-04 오후 4 24 49" src="https://github.com/user-attachments/assets/c13c3259-eb04-40d0-a7f2-c793e34a1559" />

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer

- ChatMessage 모델에 blogUrl 필드를 추가했습니다.
- 채팅 메시지 페이지네이션에 blogUrl을 추가했습니다.
- 채팅 메시지를 생성할 때, CreateChatMessageDto에서 blogUrl 기본값을 null로 설정해서 사용하고 있습니다. (blogUrl 값이 없어도 blogUrl 필드를 유지하기 위해서 null로 설정했습니다.) <img width="552" alt="스크린샷 2025-02-04 오후 4 34 56" src="https://github.com/user-attachments/assets/176a9831-7631-47a3-a0df-1c5265a8bcd8" />
- 채팅 메시지 페이지네이션에서 cursor랑 orderBy옵션이 올바르게 작동되도록 수정했습니다.

<!-- 작업한 API (선택) -->

### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| GET    | /api/v1/chat-rooms/:id/messages | 채팅 메시지 페이지네이션 | 수정                  |
