### PR TITLE
게시글 수정 API 추가

### DIFF
--- a/src/configs/app.route.ts
+++ b/src/configs/app.route.ts
@@ -44,6 +44,7 @@ export const routesV1 = {
      */
     root: `${blogRoot}/:id/${blogPostRoot}`,
     create: `${blogRoot}/:id/${blogPostRoot}`,
+    patchUpdate: `${blogRoot}/:id/${blogPostRoot}/:blogPostId`,
 
     /**
      * 블로그의 ID가 필요하지 않은 요청

--- a/src/features/attachment/commands/create-attachment/create-attachment.command-handler.ts
+++ b/src/features/attachment/commands/create-attachment/create-attachment.command-handler.ts
@@ -1,15 +1,12 @@
 import { Inject } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { Transactional } from '@nestjs-cls/transactional';
-import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
-import { Key } from '@libs/core/app-config/types/app-config.type';
 import { CreateAttachmentsCommand } from '@features/attachment/commands/create-attachment/create-attachment.command';
 import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
 import { getTsid } from 'tsid-ts';
-import { S3_SERVICE_TOKEN } from '@libs/s3/tokens/di.token';
+import { S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
 import { S3ServicePort } from '@libs/s3/services/s3.service-port';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
@@ -22,9 +19,7 @@ export class CreateAttachmentsCommandHandler
   constructor(
     @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
     private readonly attachmentRepository: AttachmentRepositoryPort,
-    @Inject(APP_CONFIG_SERVICE_DI_TOKEN)
-    private readonly appConfigService: AppConfigServicePort<Key>,
-    @Inject(S3_SERVICE_TOKEN)
+    @Inject(S3_SERVICE_DI_TOKEN)
     private readonly s3Service: S3ServicePort,
   ) {}
 

--- a/src/features/attachment/repositories/attachment.repository-port.ts
+++ b/src/features/attachment/repositories/attachment.repository-port.ts
@@ -1,4 +1,6 @@
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface AttachmentRepositoryPort
@@ -8,4 +10,9 @@ export interface AttachmentRepositoryPort
   findByUrls(urls: string[]): Promise<AttachmentEntity[]>;
 
   bulkDelete(entities: AttachmentEntity[]): Promise<void>;
+
+  findByIdsAndUploadType(
+    ids: AggregateID[],
+    uploadType?: AttachmentUploadTypeUnion,
+  ): Promise<AttachmentEntity[]>;
 }

--- a/src/features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity.ts
+++ b/src/features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity.ts
@@ -8,6 +8,7 @@ import {
   BlogPostAttachmentProps,
   CreateBlogPostAttachmentProps,
 } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity-interface';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export class BlogPostAttachmentEntity extends AggregateRoot<BlogPostAttachmentProps> {
   static readonly BLOG_POST_ATTACHMENT_PATH_PREFIX: string = 'blog-post/';
@@ -31,6 +32,10 @@ export class BlogPostAttachmentEntity extends AggregateRoot<BlogPostAttachmentPr
     });
 
     return blogPostAttachment;
+  }
+
+  get attachmentId(): AggregateID {
+    return this.props.attachmentId;
   }
 
   public validate(): void {

--- a/src/features/blog-post/blog-post-attachment/mappers/blog-post-attachment.mapper.ts
+++ b/src/features/blog-post/blog-post-attachment/mappers/blog-post-attachment.mapper.ts
@@ -3,6 +3,7 @@ import { BlogPostAttachmentProps } from '@features/blog-post/blog-post-attachmen
 import { baseSchema } from '@libs/db/base.schema';
 import { CreateEntityProps } from '@libs/ddd/entity.base';
 import { Mapper } from '@libs/ddd/mapper.interface';
+import { Injectable } from '@nestjs/common';
 import { z } from 'zod';
 
 export const blogPostAttachmentSchema = baseSchema.extend({
@@ -12,6 +13,7 @@ export const blogPostAttachmentSchema = baseSchema.extend({
 
 export type BlogPostAttachmentModel = z.TypeOf<typeof blogPostAttachmentSchema>;
 
+@Injectable()
 export class BlogPostAttachmentMapper
   implements
     Omit<

--- a/src/features/blog-post/blog-post-tag/mappers/blog-post-tag.mapper.ts
+++ b/src/features/blog-post/blog-post-tag/mappers/blog-post-tag.mapper.ts
@@ -3,6 +3,7 @@ import { BlogPostTagProps } from '@features/blog-post/blog-post-tag/domain/blog-
 import { baseSchema } from '@libs/db/base.schema';
 import { CreateEntityProps } from '@libs/ddd/entity.base';
 import { Mapper } from '@libs/ddd/mapper.interface';
+import { Injectable } from '@nestjs/common';
 import { z } from 'zod';
 
 export const blogPostTagSchema = baseSchema.extend({
@@ -12,11 +13,10 @@ export const blogPostTagSchema = baseSchema.extend({
 
 export type BlogPostTagModel = z.TypeOf<typeof blogPostTagSchema>;
 
+@Injectable()
 export class BlogPostTagMapper
   implements Omit<Mapper<BlogPostTagEntity, BlogPostTagModel>, 'toResponseDto'>
 {
-  constructor() {}
-
   toEntity(record: BlogPostTagModel): BlogPostTagEntity {
     const props: CreateEntityProps<BlogPostTagProps> = {
       id: record.id,

--- a/src/features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port.ts
+++ b/src/features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port.ts
@@ -1,7 +1,10 @@
 import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface BlogPostTagRepositoryPort
   extends RepositoryPort<BlogPostTagEntity> {
   bulkCreate(entities: BlogPostTagEntity[]): Promise<void>;
+
+  bulkDeleteByBlogPostId(blogPostId: AggregateID): Promise<void>;
 }

--- a/src/features/blog-post/blog-post-tag/repositories/blog-post-tag.repository.ts
+++ b/src/features/blog-post/blog-post-tag/repositories/blog-post-tag.repository.ts
@@ -68,10 +68,20 @@ export class BlogPostTagRepository implements BlogPostTagRepositoryPort {
   }
 
   async bulkCreate(entities: BlogPostTagEntity[]): Promise<void> {
+    if (!entities.length) {
+      return;
+    }
+
     const records = entities.map((entity) => this.mapper.toPersistence(entity));
 
     await this.txHost.tx.blogPostTag.createMany({
       data: records,
+    });
+  }
+
+  async bulkDeleteByBlogPostId(blogPostId: AggregateID): Promise<void> {
+    await this.txHost.tx.blogPostTag.deleteMany({
+      where: { blogPostId },
     });
   }
 }

--- a/src/features/blog-post/blog-post.module.ts
+++ b/src/features/blog-post/blog-post.module.ts
@@ -6,6 +6,7 @@ import { BlogPostTagMapper } from '@features/blog-post/blog-post-tag/mappers/blo
 import { BlogPostTagRepository } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository';
 import { BLOG_POST_TAG_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-tag/tokens/di.token';
 import { CreateBlogPostCommandHandler } from '@features/blog-post/commands/create-blog-post/create-blog-post.command-handler';
+import { PatchUpdateBlogPostCommandHandler } from '@features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler';
 import { BlogPostController } from '@features/blog-post/controllers/blog-post.controller';
 import { BlogPostMapper } from '@features/blog-post/mappers/blog-post.mapper';
 import { FindOneBlogPostQueryHandler } from '@features/blog-post/queries/find-one-blog-post/find-one-blog-post.query-handler';
@@ -25,7 +26,10 @@ const mappers: Provider[] = [
   BlogPostAttachmentMapper,
 ];
 
-const commandHandlers: Provider[] = [CreateBlogPostCommandHandler];
+const commandHandlers: Provider[] = [
+  CreateBlogPostCommandHandler,
+  PatchUpdateBlogPostCommandHandler,
+];
 
 const queryHandlers: Provider[] = [FindOneBlogPostQueryHandler];
 

--- a/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
@@ -24,7 +24,7 @@ import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
 import { TagEntity } from '@features/tag/domain/tag.entity';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
-import { S3_SERVICE_TOKEN } from '@libs/s3/tokens/di.token';
+import { S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
 import { S3ServicePort } from '@libs/s3/services/s3.service-port';
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
@@ -48,7 +48,7 @@ export class CreateBlogPostCommandHandler
     private readonly tagRepository: TagRepositoryPort,
     @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
     private readonly attachmentRepository: AttachmentRepositoryPort,
-    @Inject(S3_SERVICE_TOKEN)
+    @Inject(S3_SERVICE_DI_TOKEN)
     private readonly s3Service: S3ServicePort,
     @Inject(BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN)
     private readonly blogPostAttachmentRepository: BlogPostAttachmentRepositoryPort,
@@ -169,7 +169,7 @@ export class CreateBlogPostCommandHandler
         jsonContents = jsonContents.replace(oldAttachmentUrl, newAttachmentUrl);
       });
 
-      blogPost.reviseContents(JSON.parse(jsonContents));
+      blogPost.editContents(JSON.parse(jsonContents));
     }
 
     if (notExistingAttachments.length) {

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
@@ -181,22 +181,24 @@ export class PatchUpdateBlogPostCommandHandler
     if (tagNames) {
       await this.blogPostTagRepository.bulkDeleteByBlogPostId(blogPostId);
 
-      const tags = await this.tagRepository.findByNames(tagNames);
-      const existingTagNamesSet = new Set(tags.map((tag) => tag.name));
-      const newTagNames = tagNames.filter(
-        (name) => !existingTagNamesSet.has(name),
-      );
+      if (tagNames.length) {
+        const tags = await this.tagRepository.findByNames(tagNames);
+        const existingTagNamesSet = new Set(tags.map((tag) => tag.name));
+        const newTagNames = tagNames.filter(
+          (name) => !existingTagNamesSet.has(name),
+        );
 
-      const newTagEntities = newTagNames.map((name) =>
-        TagEntity.create({ name, userId }),
-      );
+        const newTagEntities = newTagNames.map((name) =>
+          TagEntity.create({ name, userId }),
+        );
 
-      await this.tagRepository.bulkCreate(newTagEntities);
-      tags.push(...newTagEntities);
+        await this.tagRepository.bulkCreate(newTagEntities);
+        tags.push(...newTagEntities);
 
-      newBlogPostTags.push(
-        ...tags.map((tag) => blogPost.createBlogPostTag(tag)),
-      );
+        newBlogPostTags.push(
+          ...tags.map((tag) => blogPost.createBlogPostTag(tag)),
+        );
+      }
     }
 
     if (fileUrls?.length) {

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
@@ -178,7 +178,7 @@ export class PatchUpdateBlogPostCommandHandler
       blogPost.editContents(contents);
     }
 
-    if (tagNames?.length) {
+    if (tagNames) {
       await this.blogPostTagRepository.bulkDeleteByBlogPostId(blogPostId);
 
       const tags = await this.tagRepository.findByNames(tagNames);

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
@@ -1,0 +1,280 @@
+import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
+import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
+import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
+import { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
+import { BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-attachment/tokens/di.token';
+import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
+import { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port';
+import { BLOG_POST_TAG_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-tag/tokens/di.token';
+import { PatchUpdateBlogPostCommand } from '@features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
+import { TagEntity } from '@features/tag/domain/tag.entity';
+import { TagRepositoryPort } from '@features/tag/repositories/tag.repository-port';
+import { TAG_REPOSITORY_DI_TOKEN } from '@features/tag/tokens/di.token';
+import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
+import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
+import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
+import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
+import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
+import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
+import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
+import { S3ServicePort } from '@libs/s3/services/s3.service-port';
+import { S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
+import { isNil } from '@libs/utils/util';
+import { Transactional } from '@nestjs-cls/transactional';
+import { Inject } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+@CommandHandler(PatchUpdateBlogPostCommand)
+export class PatchUpdateBlogPostCommandHandler
+  implements ICommandHandler<PatchUpdateBlogPostCommand, void>
+{
+  constructor(
+    @Inject(BLOG_REPOSITORY_DI_TOKEN)
+    private readonly blogRepository: BlogRepositoryPort,
+    @Inject(USER_CONNECTION_REPOSITORY_DI_TOKEN)
+    private readonly userConnectionRepository: UserConnectionRepositoryPort,
+    @Inject(BLOG_POST_REPOSITORY_DI_TOKEN)
+    private readonly blogPostRepository: BlogPostRepositoryPort,
+    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly attachmentRepository: AttachmentRepositoryPort,
+    @Inject(S3_SERVICE_DI_TOKEN)
+    private readonly s3Service: S3ServicePort,
+    @Inject(TAG_REPOSITORY_DI_TOKEN)
+    private readonly tagRepository: TagRepositoryPort,
+    @Inject(BLOG_POST_TAG_REPOSITORY_DI_TOKEN)
+    private readonly blogPostTagRepository: BlogPostTagRepositoryPort,
+    @Inject(BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly blogPostAttachmentRepository: BlogPostAttachmentRepositoryPort,
+  ) {}
+
+  @Transactional()
+  async execute(command: PatchUpdateBlogPostCommand): Promise<void> {
+    const {
+      blogId,
+      blogPostId,
+      userId,
+      title,
+      contents,
+      date,
+      location,
+      isPublic,
+      tagNames,
+      fileUrls,
+    } = command;
+
+    const blog = await this.blogRepository.findOneById(blogId);
+
+    if (isNil(blog)) {
+      throw new HttpNotFoundException({
+        code: COMMON_ERROR_CODE.RESOURCE_NOT_FOUND,
+      });
+    }
+
+    const userConnection =
+      await this.userConnectionRepository.findOneByIdAndStatus(
+        blog.connectionId,
+        UserConnectionStatus.ACCEPTED,
+      );
+
+    if (isNil(userConnection)) {
+      throw new HttpInternalServerErrorException({
+        code: COMMON_ERROR_CODE.SERVER_ERROR,
+        ctx: '블로그가 존재하는데 ACCEPTED된 userConnection이 존재하지 않을 수 없음.',
+      });
+    }
+
+    if (
+      userConnection.requesterId !== userId &&
+      userConnection.requestedId !== userId
+    ) {
+      throw new HttpForbiddenException({
+        code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
+      });
+    }
+
+    const blogPost = await this.blogPostRepository.findOneById(blogPostId, {
+      blogPostAttachments: true,
+      blogPostTags: true,
+    });
+
+    if (isNil(blogPost)) {
+      throw new HttpNotFoundException({
+        code: COMMON_ERROR_CODE.RESOURCE_NOT_FOUND,
+      });
+    }
+
+    const newBlogPostTags: BlogPostTagEntity[] = [];
+    const newBlogPostAttachments: BlogPostAttachmentEntity[] = [];
+
+    if (isPublic === true) {
+      blogPost.switchToPublic();
+    } else if (isPublic === false) {
+      blogPost.switchToPrivate();
+    }
+
+    if (title) {
+      blogPost.editTitle(title);
+    }
+
+    if (date) {
+      blogPost.editDate(date);
+    }
+
+    if (location) {
+      blogPost.editLocation(location);
+    }
+
+    if (contents) {
+      const attachmentIds = blogPost.blogPostAttachments.map(
+        (blogPostAttachment) => blogPostAttachment.attachmentId,
+      );
+
+      const existingAttachments =
+        await this.attachmentRepository.findByIdsAndUploadType(
+          attachmentIds,
+          AttachmentUploadType.IMAGE,
+        );
+
+      const jsonContents = JSON.stringify(contents);
+
+      const deletedAttachmentIdsSet = new Set<AggregateID>();
+
+      const deletedAttachments = existingAttachments.filter(
+        (existingAttachment) => {
+          const isDeleted = !jsonContents.includes(existingAttachment.url);
+
+          if (isDeleted) {
+            deletedAttachmentIdsSet.add(existingAttachment.id);
+          }
+
+          return isDeleted;
+        },
+      );
+
+      await Promise.all([
+        this.s3Service.deleteFilesFromS3(
+          deletedAttachments.map((attachment) => attachment.path),
+        ),
+        this.attachmentRepository.bulkDelete(deletedAttachments),
+      ]);
+
+      const deletedBlogPostAttachments = blogPost.blogPostAttachments.filter(
+        (blogPostAttachment) =>
+          deletedAttachmentIdsSet.has(blogPostAttachment.attachmentId),
+      );
+
+      deletedBlogPostAttachments.forEach((blogPostAttachment) =>
+        blogPost.deleteBlogPostAttachment(blogPostAttachment),
+      );
+
+      blogPost.editContents(contents);
+    }
+
+    if (tagNames?.length) {
+      await this.blogPostTagRepository.bulkDeleteByBlogPostId(blogPostId);
+
+      const tags = await this.tagRepository.findByNames(tagNames);
+      const existingTagNamesSet = new Set(tags.map((tag) => tag.name));
+      const newTagNames = tagNames.filter(
+        (name) => !existingTagNamesSet.has(name),
+      );
+
+      const newTagEntities = newTagNames.map((name) =>
+        TagEntity.create({ name, userId }),
+      );
+
+      await this.tagRepository.bulkCreate(newTagEntities);
+      tags.push(...newTagEntities);
+
+      newBlogPostTags.push(
+        ...tags.map((tag) => blogPost.createBlogPostTag(tag)),
+      );
+    }
+
+    if (fileUrls?.length) {
+      const uploadedAttachments =
+        await this.attachmentRepository.findByUrls(fileUrls);
+
+      const result = await this.s3Service.moveFiles(
+        uploadedAttachments.map((attachment) => attachment.path),
+        BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_PATH_PREFIX,
+        AttachmentEntity.ATTACHMENT_PATH_PREFIX,
+      );
+
+      const changedAttachments: AttachmentEntity[] = [];
+      const notExistingAttachments: AttachmentEntity[] = [];
+      const changedUrlInfos: {
+        oldAttachmentUrl: string;
+        newAttachmentUrl: string;
+      }[] = [];
+
+      uploadedAttachments.forEach((attachment) => {
+        const pathInfo = result[attachment.path];
+
+        if (pathInfo.isExiting) {
+          changedUrlInfos.push({
+            oldAttachmentUrl: attachment.url,
+            newAttachmentUrl: pathInfo.movedUrl,
+          });
+
+          attachment.changeLocation({
+            path: pathInfo.movedPath,
+            url: pathInfo.movedUrl,
+          });
+
+          changedAttachments.push(attachment);
+        } else {
+          notExistingAttachments.push(attachment);
+        }
+      });
+
+      if (changedAttachments.length) {
+        await Promise.all(
+          changedAttachments.map(
+            async (attachment) =>
+              await this.attachmentRepository.update(attachment),
+          ),
+        );
+
+        if (contents) {
+          let jsonContents = JSON.stringify(contents);
+
+          changedUrlInfos.forEach(({ oldAttachmentUrl, newAttachmentUrl }) => {
+            jsonContents = jsonContents.replace(
+              oldAttachmentUrl,
+              newAttachmentUrl,
+            );
+          });
+
+          blogPost.editContents(JSON.parse(jsonContents));
+        }
+      }
+
+      if (notExistingAttachments.length) {
+        notExistingAttachments.forEach((attachment) => attachment.delete());
+
+        await this.attachmentRepository.bulkDelete(notExistingAttachments);
+      }
+
+      newBlogPostAttachments.push(
+        ...changedAttachments.map((attachment) =>
+          blogPost.createBlogPostAttachment(attachment),
+        ),
+      );
+    }
+
+    await Promise.all([
+      this.blogPostRepository.update(blogPost),
+      this.blogPostTagRepository.bulkCreate(newBlogPostTags),
+      this.blogPostAttachmentRepository.bulkCreate(newBlogPostAttachments),
+    ]);
+  }
+}

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command.ts
@@ -1,0 +1,31 @@
+import { Command, CommandProps } from '@libs/ddd/command.base';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
+
+export class PatchUpdateBlogPostCommand extends Command implements ICommand {
+  readonly blogId: AggregateID;
+  readonly blogPostId: AggregateID;
+  readonly userId: AggregateID;
+  readonly title?: string;
+  readonly contents?: Array<Record<string, any>>;
+  readonly date?: string;
+  readonly location?: string;
+  readonly isPublic?: boolean;
+  readonly tagNames?: string[];
+  readonly fileUrls?: string[];
+
+  constructor(props: CommandProps<PatchUpdateBlogPostCommand>) {
+    super(props);
+
+    this.blogId = props.blogId;
+    this.blogPostId = props.blogPostId;
+    this.userId = props.userId;
+    this.title = props.title;
+    this.contents = props.contents;
+    this.date = props.date;
+    this.location = props.location;
+    this.isPublic = props.isPublic;
+    this.tagNames = props.tagNames;
+    this.fileUrls = props.fileUrls;
+  }
+}

--- a/src/features/blog-post/controllers/blog-post.controller.ts
+++ b/src/features/blog-post/controllers/blog-post.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { routesV1 } from '@config/app.route';
@@ -15,6 +24,8 @@ import { FindOneBlogPostQueryHandler } from '@features/blog-post/queries/find-on
 import { HandlerReturnType } from '@libs/types/type';
 import { BlogPostResponseDto } from '@features/blog-post/dtos/response/blog-post.response-dto';
 import { HydratedTagResponseDto } from '@features/tag/dtos/response/hydrated-tag.response-dto';
+import { PatchUpdateBlogPostRequestBodyDto } from '@features/blog-post/dtos/request/patch-update-blog-post.request-body-dto';
+import { PatchUpdateBlogPostCommand } from '@features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command';
 
 @ApiTags('BlogPost')
 @ApiInternalServerErrorBuilder()
@@ -75,6 +86,26 @@ export class BlogPostController {
       tags: result.tags.map((tag) => new HydratedTagResponseDto(tag)),
     });
   }
-}
 
-// 변경사항 반영
+  @ApiBlogPost.PatchUpdate({
+    summary: '게시글 PATCH update',
+    description: 'tag값이 올 경우 기존 태그 삭제 후 새로 추가',
+  })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Patch(routesV1.blogPost.patchUpdate)
+  async patchUpdate(
+    @User('sub') userId: AggregateID,
+    @Param('id', ParsePositiveBigIntPipe) blogId: string,
+    @Param('blogPostId', ParsePositiveBigIntPipe) blogPostId: string,
+    @Body() requestBodyDto: PatchUpdateBlogPostRequestBodyDto,
+  ) {
+    const command = new PatchUpdateBlogPostCommand({
+      ...requestBodyDto,
+      blogId: BigInt(blogId),
+      blogPostId: BigInt(blogPostId),
+      userId,
+    });
+
+    await this.commandBus.execute<PatchUpdateBlogPostCommand, void>(command);
+  }
+}

--- a/src/features/blog-post/controllers/blog-post.swagger.ts
+++ b/src/features/blog-post/controllers/blog-post.swagger.ts
@@ -2,6 +2,7 @@ import { applyDecorators, HttpStatus } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiCreatedResponse,
+  ApiNoContentResponse,
   ApiOkResponse,
   ApiOperation,
 } from '@nestjs/swagger';
@@ -25,7 +26,6 @@ export const ApiBlogPost: ApiOperator<keyof BlogPostController> = {
     return applyDecorators(
       ApiOperation({
         ...apiOperationOptions,
-        summary: '블로그 포스트 생성',
       }),
       ApiBearerAuth('access-token'),
       ApiCreatedResponse({
@@ -135,6 +135,139 @@ export const ApiBlogPost: ApiOperator<keyof BlogPostController> = {
         {
           code: COMMON_ERROR_CODE.RESOURCE_NOT_FOUND,
           description: '해당 blog가 존재하지 않음.',
+        },
+      ]),
+    );
+  },
+
+  PatchUpdate: (
+    apiOperationOptions: ApiOperationOptionsWithSummary,
+  ): MethodDecorator => {
+    return applyDecorators(
+      ApiOperation({
+        ...apiOperationOptions,
+      }),
+      ApiBearerAuth('access-token'),
+      ApiNoContentResponse({
+        description: '정상적으로 블로그 게시글 수정됨.',
+      }),
+      HttpBadRequestException.swaggerBuilder(HttpStatus.BAD_REQUEST, [
+        {
+          code: COMMON_ERROR_CODE.INVALID_REQUEST_PARAMETER,
+          description: 'blogPost나 blog의 id가 numeric string이 아님.',
+          additionalErrors: {
+            errors: [
+              {
+                value: '6741371996205169262ㅁㄴㅇㅁㄴㅇ',
+                property: 'id',
+                reason: 'param internal the id must be a numeric string',
+              },
+            ],
+            errorType: CustomValidationError,
+          },
+        },
+        {
+          code: COMMON_ERROR_CODE.INVALID_REQUEST_PARAMETER,
+          description: 'tagNames가 중복됨.',
+          additionalErrors: {
+            errors: [
+              {
+                property: 'tagNames',
+                value: ['abc', 'abc'],
+                reason: "All tagNames's elements must be unique",
+              },
+            ],
+            errorType: CustomValidationError,
+          },
+        },
+        {
+          code: COMMON_ERROR_CODE.INVALID_REQUEST_PARAMETER,
+          description: 'tagNames의 요소가 1 이상 20 이하가 아님',
+          additionalErrors: {
+            errors: [
+              {
+                property: 'tagNames',
+                value: ['', 'abc'],
+                reason:
+                  'each value in tagNames must be longer than or equal to 1 and shorter than or equal to 20 characters',
+              },
+            ],
+            errorType: CustomValidationError,
+          },
+        },
+        {
+          code: COMMON_ERROR_CODE.INVALID_REQUEST_PARAMETER,
+          description: 'location이 1 이상 100 이하가 아님',
+          additionalErrors: {
+            errors: [
+              {
+                property: 'location',
+                value: '',
+                reason: 'location must be longer than or equal to 1 characters',
+              },
+            ],
+            errorType: CustomValidationError,
+          },
+        },
+        {
+          code: COMMON_ERROR_CODE.INVALID_REQUEST_PARAMETER,
+          description: 'title이 1 이상 255 이하가 아님',
+          additionalErrors: {
+            errors: [
+              {
+                property: 'title',
+                value: '',
+                reason: 'title must be longer than or equal to 1 characters',
+              },
+            ],
+            errorType: CustomValidationError,
+          },
+        },
+        {
+          code: COMMON_ERROR_CODE.INVALID_REQUEST_PARAMETER,
+          description: 'date가 date format이 아님',
+          additionalErrors: {
+            errors: [
+              {
+                property: 'date',
+                value: '2025-0122',
+                reason: 'date must be a valid ISO 8601 date string',
+              },
+            ],
+            errorType: CustomValidationError,
+          },
+        },
+        {
+          code: COMMON_ERROR_CODE.INVALID_REQUEST_PARAMETER,
+          description: '그 외 기타 등등 많음',
+          additionalErrors: {
+            errors: [
+              {
+                property: 'contents',
+                value: [],
+                reason: 'contents should not be empty',
+              },
+            ],
+            errorType: CustomValidationError,
+          },
+        },
+      ]),
+      HttpUnauthorizedException.swaggerBuilder(HttpStatus.UNAUTHORIZED, [
+        {
+          code: COMMON_ERROR_CODE.INVALID_TOKEN,
+          description: '유효하지 않은 토큰으로 인해서 발생하는 에러.',
+        },
+      ]),
+      HttpForbiddenException.swaggerBuilder(HttpStatus.FORBIDDEN, [
+        {
+          code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
+          description: '해당 blog의 커넥션에 속해있지 않음.',
+        },
+      ]),
+      HttpNotFoundException.swaggerBuilder(HttpStatus.NOT_FOUND, [
+        {
+          code: COMMON_ERROR_CODE.RESOURCE_NOT_FOUND,
+          description: '해당 blog가 존재하지 않거나 게시글이 존재하지 않음.',
         },
       ]),
     );

--- a/src/features/blog-post/domain/blog-post.entity.ts
+++ b/src/features/blog-post/domain/blog-post.entity.ts
@@ -13,6 +13,7 @@ import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog
 import { UserEntity } from '@features/user/domain/user.entity';
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { isNil } from '@libs/utils/util';
 
 export class BlogPostEntity extends AggregateRoot<BlogPostProps> {
   static create(create: CreateBlogPostProps): BlogPostEntity {
@@ -36,8 +37,32 @@ export class BlogPostEntity extends AggregateRoot<BlogPostProps> {
     return blogPost;
   }
 
-  reviseContents(contents: Array<Record<string, any>>): void {
+  editContents(contents: Array<Record<string, any>>): void {
     this.props.contents = contents;
+  }
+
+  editTitle(title: string): void {
+    this.props.title = title;
+  }
+
+  editDate(date: string): void {
+    this.props.date = date;
+  }
+
+  editLocation(location: string): void {
+    this.props.location = location;
+  }
+
+  private changeIsPublic(isPublic: boolean): void {
+    this.props.isPublic = isPublic;
+  }
+
+  switchToPublic(): void {
+    this.changeIsPublic(true);
+  }
+
+  switchToPrivate(): void {
+    this.changeIsPublic(false);
   }
 
   hydrateUser(user: UserEntity): void {
@@ -75,8 +100,28 @@ export class BlogPostEntity extends AggregateRoot<BlogPostProps> {
     return blogPostAttachment;
   }
 
+  deleteBlogPostAttachment(blogPostAttachment: BlogPostAttachmentEntity): void {
+    if (isNil(this.props.blogPostAttachments)) {
+      return;
+    }
+
+    const index = this.props.blogPostAttachments.findIndex(
+      (attachment) => attachment.id === blogPostAttachment.id,
+    );
+
+    if (index === -1) {
+      return;
+    }
+
+    this.props.blogPostAttachments.splice(index, 1);
+  }
+
   get contents(): Array<Record<string, any>> {
     return this.props.contents;
+  }
+
+  get blogPostAttachments(): BlogPostAttachmentEntity[] {
+    return this.props.blogPostAttachments || [];
   }
 
   public validate(): void {

--- a/src/features/blog-post/dtos/request/patch-update-blog-post.request-body-dto.ts
+++ b/src/features/blog-post/dtos/request/patch-update-blog-post.request-body-dto.ts
@@ -1,0 +1,14 @@
+import { CreateBlogPostRequestBodyDto } from '@features/blog-post/dtos/request/create-blog-post.request-body-dto';
+import { ApiPropertyOptional, OmitType, PartialType } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class PatchUpdateBlogPostRequestBodyDto extends PartialType(
+  OmitType(CreateBlogPostRequestBodyDto, ['isPublic'] as const),
+) {
+  @ApiPropertyOptional({
+    description: '해당 게시글 공개 여부',
+  })
+  @IsBoolean()
+  @IsOptional()
+  isPublic?: boolean;
+}

--- a/src/features/blog-post/repositories/blog-post.repository-port.ts
+++ b/src/features/blog-post/repositories/blog-post.repository-port.ts
@@ -1,5 +1,10 @@
 import { RepositoryPort } from '@libs/ddd/repository.port';
 import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
 
+export interface BlogPostInclude {
+  blogPostAttachments: true;
+  blogPostTags: true;
+}
+
 export interface BlogPostRepositoryPort
-  extends RepositoryPort<BlogPostEntity> {}
+  extends RepositoryPort<BlogPostEntity, BlogPostInclude> {}

--- a/src/features/blog-post/repositories/blog-post.repository.ts
+++ b/src/features/blog-post/repositories/blog-post.repository.ts
@@ -9,7 +9,10 @@ import {
 } from '@features/blog-post/mappers/blog-post.mapper';
 import { PrismaService } from '@libs/core/prisma/services/prisma.service';
 import { AggregateID } from '@libs/ddd/entity.base';
-import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import {
+  BlogPostInclude,
+  BlogPostRepositoryPort,
+} from '@features/blog-post/repositories/blog-post.repository-port';
 
 @Injectable()
 export class BlogPostRepository implements BlogPostRepositoryPort {
@@ -21,9 +24,13 @@ export class BlogPostRepository implements BlogPostRepositoryPort {
     private readonly mapper: BlogPostMapper,
   ) {}
 
-  async findOneById(id: AggregateID): Promise<BlogPostEntity | undefined> {
+  async findOneById(
+    id: AggregateID,
+    include: BlogPostInclude,
+  ): Promise<BlogPostEntity | undefined> {
     const record = await this.txHost.tx.blogPost.findUnique({
       where: { id, deletedAt: null },
+      include,
     });
 
     return record

--- a/src/features/tag/repositories/tag.repository.ts
+++ b/src/features/tag/repositories/tag.repository.ts
@@ -68,6 +68,10 @@ export class TagRepository implements TagRepositoryPort {
   }
 
   async findByNames(names: string[]): Promise<TagEntity[]> {
+    if (!names.length) {
+      return [];
+    }
+
     const record = await this.txHost.tx.tag.findMany({
       where: { name: { in: names } },
     });
@@ -76,6 +80,10 @@ export class TagRepository implements TagRepositoryPort {
   }
 
   async bulkCreate(entities: TagEntity[]): Promise<void> {
+    if (!entities.length) {
+      return;
+    }
+
     const record = entities.map((entity) => this.mapper.toPersistence(entity));
 
     await this.txHost.tx.tag.createMany({ data: record });

--- a/src/features/user/user-connection/repositories/user-connection.repository.ts
+++ b/src/features/user/user-connection/repositories/user-connection.repository.ts
@@ -92,13 +92,12 @@ export class UserConnectionRepository implements UserConnectionRepositoryPort {
         OR: [
           {
             requesterId: userId,
-            status,
           },
           {
             requestedId: userId,
-            status,
           },
         ],
+        status,
         deletedAt: null,
       },
     });

--- a/src/libs/logger/factories/winston-logger-options.factory.ts
+++ b/src/libs/logger/factories/winston-logger-options.factory.ts
@@ -24,7 +24,7 @@ export class WinstonLoggerModuleOptionsFactory
     return {
       transports: [
         new winston.transports.Console({
-          level: 'info',
+          level: this.appConfigService.isLocal() ? 'debug' : 'info',
           format: winston.format.combine(
             winston.format.colorize({ level: true }), // 색깔 넣어서 출력
             winston.format.timestamp({

--- a/src/libs/s3/s3.module.ts
+++ b/src/libs/s3/s3.module.ts
@@ -6,7 +6,7 @@ import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-co
 import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { Key } from '@libs/core/app-config/types/app-config.type';
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import { S3_CLIENT_TOKEN, S3_SERVICE_TOKEN } from '@libs/s3/tokens/di.token';
+import { S3_CLIENT_TOKEN, S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
 import { S3Service } from '@libs/s3/services/s3.service';
 
 @Module({
@@ -30,10 +30,10 @@ import { S3Service } from '@libs/s3/services/s3.service';
       },
     },
     {
-      provide: S3_SERVICE_TOKEN,
+      provide: S3_SERVICE_DI_TOKEN,
       useClass: S3Service,
     },
   ],
-  exports: [S3_SERVICE_TOKEN],
+  exports: [S3_SERVICE_DI_TOKEN],
 })
 export class S3Module {}

--- a/src/libs/s3/tokens/di.token.ts
+++ b/src/libs/s3/tokens/di.token.ts
@@ -1,3 +1,3 @@
 export const S3_CLIENT_TOKEN = Symbol('S3_CLIENT_TOKEN');
 
-export const S3_SERVICE_TOKEN = Symbol('S3_SERVICE_TOKEN');
+export const S3_SERVICE_DI_TOKEN = Symbol('S3_SERVICE_DI_TOKEN');


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#97 

<!-- 내용 (필수) -->

### Description

게시글 수정 API 추가했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer

생각보다 update API를 구현하면서 file changed가 커져서 PR을 분리해서 올리려 합니다.

게시글 첨부파일의 경우 contents가 왔을 때 기존 IMAGE로 업로드 된 attachment를 조회하고 해당 attachment의 url이 contents 내에 존재하지 않으면 삭제시킵니다.
새로 업로드 된 파일의 경우 기존과 동일한 로직을 가져갑니다.

tagNames의 경우 값이 왔을 때 기존의 태그들을 전부 지우고 새로 만듭니다.

<!-- 작업한 API (선택) -->

### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| PATCH    | /api/blogs/:id/blog-posts/:blogPostId | 블로그 게시글 PATCH update API | 추가                   |
