### PR TITLE
블로그, 유저 컬럼 추가 및 관련 로직 추가

### DIFF
--- a/prisma/migrations/20250206081612_add_columns_in_blog_user/migration.sql
+++ b/prisma/migrations/20250206081612_add_columns_in_blog_user/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "blogs" ADD COLUMN     "background_image_path" VARCHAR(255),
+ADD COLUMN     "d_day_start_date" VARCHAR(20) NOT NULL DEFAULT 'temp',
+ADD COLUMN     "description" VARCHAR(255) NOT NULL DEFAULT 'temp';
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "profile_image_path" VARCHAR(255) NOT NULL DEFAULT 'temp';

--- a/prisma/migrations/20250206081844_drop_default_on_user_blog/migration.sql
+++ b/prisma/migrations/20250206081844_drop_default_on_user_blog/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "blogs" ALTER COLUMN "d_day_start_date" DROP DEFAULT,
+ALTER COLUMN "description" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "profile_image_path" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,7 @@ model User {
   loginType        LoginTypeEnum @map("login_type")
   role             UserRoleEnum  @default(USER)
   isEmailVerified  Boolean       @default(false) @map("is_email_verified") @db.Boolean
-  profileImagePath String        @default("temp") @map("profile_image_path") @db.VarChar(255)
+  profileImagePath String        @map("profile_image_path") @db.VarChar(255)
   mbti             MbtiEnum?
   createdAt        DateTime      @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt        DateTime      @default(now()) @map("updated_at") @db.Timestamptz(6)
@@ -76,8 +76,8 @@ model Blog {
   createdBy           BigInt    @map("created_by") @db.BigInt()
   connectionId        BigInt    @unique(map: "uq_blogs_connection_id") @map("connection_id") @db.BigInt()
   name                String    @db.VarChar(30)
-  description         String    @default("temp") @db.VarChar(255)
-  dDayStartDate       String    @default("temp") @map("d_day_start_date") @db.VarChar(20)
+  description         String    @db.VarChar(255)
+  dDayStartDate       String    @map("d_day_start_date") @db.VarChar(20)
   backgroundImagePath String?   @map("background_image_path") @db.VarChar(255)
   createdAt           DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt           DateTime  @default(now()) @map("updated_at") @db.Timestamptz(6)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,17 +13,18 @@ datasource db {
 }
 
 model User {
-  id              BigInt        @id(map: "pk_users")
-  nickname        String        @db.VarChar(20)
-  email           String        @db.VarChar(255)
-  password        String        @db.VarChar(255)
-  loginType       LoginTypeEnum @map("login_type")
-  role            UserRoleEnum  @default(USER)
-  isEmailVerified Boolean       @default(false) @map("is_email_verified") @db.Boolean
-  mbti            MbtiEnum?
-  createdAt       DateTime      @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt       DateTime      @default(now()) @map("updated_at") @db.Timestamptz(6)
-  deletedAt       DateTime?     @map("deleted_at") @db.Timestamptz(6)
+  id               BigInt        @id(map: "pk_users")
+  nickname         String        @db.VarChar(20)
+  email            String        @db.VarChar(255)
+  password         String        @db.VarChar(255)
+  loginType        LoginTypeEnum @map("login_type")
+  role             UserRoleEnum  @default(USER)
+  isEmailVerified  Boolean       @default(false) @map("is_email_verified") @db.Boolean
+  profileImagePath String        @default("temp") @map("profile_image_path") @db.VarChar(255)
+  mbti             MbtiEnum?
+  createdAt        DateTime      @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt        DateTime      @default(now()) @map("updated_at") @db.Timestamptz(6)
+  deletedAt        DateTime?     @map("deleted_at") @db.Timestamptz(6)
 
   userVerifyTokens     UserVerifyToken[]
   requestedConnections UserConnection[]  @relation("RequestedConnection")
@@ -71,13 +72,16 @@ model UserConnection {
 }
 
 model Blog {
-  id           BigInt    @id(map: "pk_blogs")
-  createdBy    BigInt    @map("created_by") @db.BigInt()
-  connectionId BigInt    @unique(map: "uq_blogs_connection_id") @map("connection_id") @db.BigInt()
-  name         String    @db.VarChar(30)
-  createdAt    DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt    DateTime  @default(now()) @map("updated_at") @db.Timestamptz(6)
-  deletedAt    DateTime? @map("deleted_at") @db.Timestamptz(6)
+  id                  BigInt    @id(map: "pk_blogs")
+  createdBy           BigInt    @map("created_by") @db.BigInt()
+  connectionId        BigInt    @unique(map: "uq_blogs_connection_id") @map("connection_id") @db.BigInt()
+  name                String    @db.VarChar(30)
+  description         String    @default("temp") @db.VarChar(255)
+  dDayStartDate       String    @default("temp") @map("d_day_start_date") @db.VarChar(20)
+  backgroundImagePath String?   @map("background_image_path") @db.VarChar(255)
+  createdAt           DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt           DateTime  @default(now()) @map("updated_at") @db.Timestamptz(6)
+  deletedAt           DateTime? @map("deleted_at") @db.Timestamptz(6)
 
   connection UserConnection @relation(fields: [connectionId], references: [id], onDelete: Cascade)
   blogPosts  BlogPost[]

--- a/src/features/blog/blog.module.ts
+++ b/src/features/blog/blog.module.ts
@@ -1,3 +1,4 @@
+import { AttachmentModule } from '@features/attachment/attachment.module';
 import { CreateBlogCommandHandler } from '@features/blog/commands/create-blog/create-blog.command-handler';
 import { BlogController } from '@features/blog/controllers/blog.controller';
 import { BlogMapper } from '@features/blog/mappers/blog.mapper';
@@ -5,7 +6,9 @@ import { FindOneBlogByUserIdQueryHandler } from '@features/blog/queries/find-one
 import { BlogRepository } from '@features/blog/repositories/blog.repository';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { UserModule } from '@features/user/user.module';
+import { S3Module } from '@libs/s3/s3.module';
 import { Module, Provider } from '@nestjs/common';
+import { NestjsFormDataModule } from 'nestjs-form-data';
 
 const controllers = [BlogController];
 
@@ -20,7 +23,7 @@ const repositories: Provider[] = [
 ];
 
 @Module({
-  imports: [UserModule],
+  imports: [UserModule, NestjsFormDataModule, AttachmentModule, S3Module],
   controllers: [...controllers],
   providers: [
     ...mappers,

--- a/src/features/blog/commands/create-blog/create-blog.command.ts
+++ b/src/features/blog/commands/create-blog/create-blog.command.ts
@@ -5,11 +5,21 @@ import { AggregateID } from '@libs/ddd/entity.base';
 export class CreateBlogCommand extends Command implements ICommand {
   readonly userId: AggregateID;
   readonly name: string;
+  readonly description: string;
+  readonly dDayStartDate: string;
+  readonly backgroundImageFile: {
+    mimeType: string;
+    capacity: number;
+    buffer: Buffer;
+  } | null;
 
   constructor(props: CommandProps<CreateBlogCommand>) {
     super(props);
 
     this.userId = props.userId;
     this.name = props.name;
+    this.description = props.description;
+    this.dDayStartDate = props.dDayStartDate;
+    this.backgroundImageFile = props.backgroundImageFile;
   }
 }

--- a/src/features/blog/controllers/blog.swagger.ts
+++ b/src/features/blog/controllers/blog.swagger.ts
@@ -1,6 +1,8 @@
 import { applyDecorators, HttpStatus } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
   ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
@@ -29,6 +31,42 @@ export const ApiBlog: ApiOperator<keyof BlogController> = {
         ...apiOperationOptions,
       }),
       ApiBearerAuth('access-token'),
+      ApiConsumes('multipart/form-data'),
+      ApiBody({
+        description:
+          'Mime-Type은 image/png, image/jpeg 타입만 허용됨.<br>' +
+          '파일 크기는 10MB 까지만 허용됨.',
+        schema: {
+          type: 'object',
+          required: ['name', 'description', 'dDayStartDate'],
+          properties: {
+            backgroundImageFile: {
+              type: 'string',
+              format: 'binary',
+              nullable: true,
+            },
+            name: {
+              description: '블로그 이름',
+              type: 'string',
+              minLength: 1,
+              maxLength: 30,
+            },
+            description: {
+              description: '블로그 설명',
+              type: 'string',
+              minLength: 1,
+              maxLength: 255,
+            },
+            dDayStartDate: {
+              description:
+                '블로그 시작일. 시간 제외 날짜 값까지만 허용. ex)2025-02-06',
+              type: 'string',
+              format: 'date',
+              maxLength: 10,
+            },
+          },
+        },
+      }),
       ApiCreatedResponse({
         description: '정상적으로 블로그 생성됨.',
         type: IdResponseDto,

--- a/src/features/blog/domain/blog.entity-interface.ts
+++ b/src/features/blog/domain/blog.entity-interface.ts
@@ -5,6 +5,9 @@ export interface BlogProps {
   createdBy: AggregateID;
   connectionId: AggregateID;
   name: string;
+  description: string;
+  backgroundImagePath: string | null;
+  dDayStartDate: string;
   deletedAt: Date | null;
 
   members?: HydratedUserEntityProps[];
@@ -14,6 +17,9 @@ export interface CreateBlogProps {
   createdBy: AggregateID;
   connectionId: AggregateID;
   name: string;
+  description: string;
+  backgroundImagePath: string | null;
+  dDayStartDate: string;
 }
 
 export interface HydratedBlogEntityProps extends BaseEntityProps {

--- a/src/features/blog/domain/blog.entity.ts
+++ b/src/features/blog/domain/blog.entity.ts
@@ -14,6 +14,17 @@ import { UserEntity } from '@features/user/domain/user.entity';
 import { HydratedUserEntityProps } from '@features/user/domain/user.entity-interface';
 
 export class BlogEntity extends AggregateRoot<BlogProps> {
+  static readonly BLOG_ATTACHMENT_URL = process.env.BLOG_ATTACHMENT_URL;
+
+  private static readonly BLOG_ATTACHMENT_PATH_PREFIX = 'blog/';
+  static readonly BLOG_BACKGROUND_IMAGE_PATH_PREFIX =
+    BlogEntity.BLOG_ATTACHMENT_PATH_PREFIX + 'background-image/';
+
+  static readonly BLOG_BACKGROUND_IMAGE_MIME_TYPE: readonly string[] = [
+    'image/png',
+    'image/jpeg',
+  ];
+
   static create(create: CreateBlogProps): BlogEntity {
     const id = getTsid().toBigInt();
 
@@ -49,6 +60,12 @@ export class BlogEntity extends AggregateRoot<BlogProps> {
 
   get members(): HydratedUserEntityProps[] | null {
     return this.props.members || null;
+  }
+
+  get backgroundImageUrl(): string | null {
+    return this.props.backgroundImagePath
+      ? BlogEntity.BLOG_ATTACHMENT_URL + this.props.backgroundImagePath
+      : null;
   }
 
   hydrateMember(user: UserEntity) {

--- a/src/features/blog/dtos/request/create-blog.request-body-dto.ts
+++ b/src/features/blog/dtos/request/create-blog.request-body-dto.ts
@@ -1,5 +1,15 @@
+import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { BlogEntity } from '@features/blog/domain/blog.entity';
+import { IsNullable } from '@libs/api/decorators/is-nullable.decorator';
 import { ApiProperty } from '@nestjs/swagger';
-import { Length } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsDateString, Length, MaxLength } from 'class-validator';
+import {
+  HasMimeType,
+  IsFile,
+  MaxFileSize,
+  MemoryStoredFile,
+} from 'nestjs-form-data';
 
 export class CreateBlogRequestBodyDto {
   @ApiProperty({
@@ -9,4 +19,32 @@ export class CreateBlogRequestBodyDto {
   })
   @Length(1, 30)
   name: string;
+
+  @ApiProperty({
+    description: '블로그 설명',
+    minLength: 1,
+    maxLength: 255,
+  })
+  @Length(1, 255)
+  description: string;
+
+  @ApiProperty({
+    description: '블로그 시작일. 시간 제외 날짜 값까지만 허용. ex)2025-02-06',
+    format: 'date',
+    maxLength: 10,
+  })
+  @IsDateString()
+  @MaxLength(10)
+  dDayStartDate: string;
+
+  @ApiProperty({
+    description: '블로그 배경 이미지 파일',
+    nullable: true,
+  })
+  @IsFile()
+  @HasMimeType([...BlogEntity.BLOG_BACKGROUND_IMAGE_MIME_TYPE])
+  @MaxFileSize(AttachmentEntity.ATTACHMENT_CAPACITY_MAX)
+  @IsNullable()
+  @Transform(({ value }) => (value ? value : null))
+  backgroundImageFile: MemoryStoredFile | null;
 }

--- a/src/features/blog/dtos/response/blog.response-dto.ts
+++ b/src/features/blog/dtos/response/blog.response-dto.ts
@@ -10,6 +10,9 @@ export interface CreateBlogResponseDtoProps extends CreateBaseResponseDtoProps {
   createdBy: AggregateID;
   connectionId: AggregateID;
   name: string;
+  description: string;
+  dDayStartDate: string;
+  backgroundImageUrl: string | null;
   members?: HydratedUserResponseDto[];
 }
 
@@ -24,6 +27,26 @@ export class BlogResponseDto
     maxLength: 30,
   })
   readonly name: string;
+
+  @ApiProperty({
+    description: '블로그 설명',
+    minLength: 1,
+    maxLength: 255,
+  })
+  readonly description: string;
+
+  @ApiProperty({
+    description: 'D-day 시작일 (날짜까지만)',
+    format: 'date',
+  })
+  readonly dDayStartDate: string;
+
+  @ApiProperty({
+    description: '블로그 배경 이미지 url',
+    format: 'uri',
+    nullable: true,
+  })
+  readonly backgroundImageUrl: string | null;
 
   @ApiProperty({
     format: 'int64',

--- a/src/features/blog/mappers/blog.mapper.ts
+++ b/src/features/blog/mappers/blog.mapper.ts
@@ -14,6 +14,9 @@ export const blogSchema = baseSchema.extend({
   createdBy: z.bigint(),
   connectionId: z.bigint(),
   name: z.string().max(30),
+  description: z.string().max(255),
+  backgroundImagePath: z.nullable(z.string().max(255)),
+  dDayStartDate: z.string().max(20),
   deletedAt: z.preprocess(
     (val: any) => (val === null ? null : new Date(val)),
     z.nullable(z.date()),
@@ -34,6 +37,9 @@ export class BlogMapper
         connectionId: blog.connectionId,
         createdBy: blog.createdBy,
         name: blog.name,
+        description: blog.description,
+        backgroundImagePath: blog.backgroundImagePath,
+        dDayStartDate: blog.dDayStartDate,
         deletedAt: blog.deletedAt,
       },
       createdAt: blog.createdAt,
@@ -44,8 +50,10 @@ export class BlogMapper
   }
 
   toPersistence(entity: BlogEntity): BlogModel {
+    const props = entity.getProps();
+
     return blogSchema.parse({
-      ...entity.getProps(),
+      ...props,
     });
   }
 
@@ -55,10 +63,13 @@ export class BlogMapper
     const createdDtoProps: CreateBlogResponseDtoProps = {
       id: props.id,
       name: props.name,
+      description: props.description,
+      dDayStartDate: props.dDayStartDate,
+      backgroundImageUrl: entity.backgroundImageUrl,
       connectionId: props.connectionId,
       createdBy: props.createdBy,
-      createdAt: entity.createdAt,
-      updatedAt: entity.updatedAt,
+      createdAt: props.createdAt,
+      updatedAt: props.updatedAt,
     };
 
     if (props.members) {

--- a/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
+++ b/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
@@ -1,3 +1,4 @@
+import { BlogEntity } from '@features/blog/domain/blog.entity';
 import { FindOneBlogByUserIdQuery } from '@features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query';
 import { UserEntity } from '@features/user/domain/user.entity';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
@@ -55,6 +56,11 @@ export class FindOneBlogByUserIdQueryHandler
     return {
       id: blog.id,
       name: blog.name,
+      description: blog.description,
+      dDayStartDate: blog.dDayStartDate,
+      backgroundImageUrl: blog.backgroundImagePath
+        ? BlogEntity.BLOG_ATTACHMENT_URL + blog.backgroundImagePath
+        : null,
       connectionId: blog.connectionId,
       createdBy: blog.createdBy,
       members: [

--- a/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
+++ b/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
@@ -1,4 +1,5 @@
 import { FindOneBlogByUserIdQuery } from '@features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query';
+import { UserEntity } from '@features/user/domain/user.entity';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { PrismaService } from '@libs/core/prisma/services/prisma.service';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
@@ -56,7 +57,16 @@ export class FindOneBlogByUserIdQueryHandler
       name: blog.name,
       connectionId: blog.connectionId,
       createdBy: blog.createdBy,
-      members: [blog.connection.requesterUser, blog.connection.requestedUser],
+      members: [
+        {
+          ...blog.connection.requesterUser,
+          profileImageUrl: `${UserEntity.USER_ATTACHMENT_URL}/${blog.connection.requesterUser.profileImagePath}`,
+        },
+        {
+          ...blog.connection.requestedUser,
+          profileImageUrl: `${UserEntity.USER_ATTACHMENT_URL}/${blog.connection.requestedUser.profileImagePath}`,
+        },
+      ],
       createdAt: blog.createdAt,
       updatedAt: blog.updatedAt,
     };

--- a/src/features/user/domain/user.entity-interface.ts
+++ b/src/features/user/domain/user.entity-interface.ts
@@ -14,6 +14,7 @@ export interface UserProps {
   password: string;
   loginType: UserLoginTypeUnion;
   isEmailVerified: boolean;
+  profileImagePath: string;
   mbti: UserMbtiUnion | null;
   deletedAt: Date | null;
 
@@ -32,4 +33,5 @@ export interface CreateUserProps {
 
 export interface HydratedUserEntityProps extends BaseEntityProps {
   nickname: string;
+  profileImageUrl: string;
 }

--- a/src/features/user/domain/user.entity.ts
+++ b/src/features/user/domain/user.entity.ts
@@ -30,6 +30,14 @@ import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 
 export class UserEntity extends AggregateRoot<UserProps> {
+  static readonly USER_ATTACHMENT_URL = process.env.USER_ATTACHMENT_URL;
+  private static readonly USER_DEFAULT_PROFILE_IMAGE_PATH =
+    process.env.USER_DEFAULT_PROFILE_IMAGE_PATH;
+
+  private static readonly USER_ATTACHMENT_PATH_PREFIX = 'user/';
+  static readonly USER_PROFILE_ATTACHMENT_PATH_PREFIX =
+    UserEntity.USER_ATTACHMENT_PATH_PREFIX + 'profile-image/';
+
   static async create(create: CreateUserProps): Promise<UserEntity> {
     const id = getTsid().toBigInt();
 
@@ -38,6 +46,7 @@ export class UserEntity extends AggregateRoot<UserProps> {
       role: UserRole.USER,
       isEmailVerified: false,
       deletedAt: null,
+      profileImagePath: `${UserEntity.USER_ATTACHMENT_URL}/${UserEntity.USER_DEFAULT_PROFILE_IMAGE_PATH}`,
     };
 
     const user = new UserEntity({ id, props });
@@ -107,9 +116,14 @@ export class UserEntity extends AggregateRoot<UserProps> {
     return {
       id: this.id,
       nickname: this.props.nickname,
+      profileImageUrl: this.profileImageUrl,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };
+  }
+
+  get profileImageUrl(): string {
+    return `${UserEntity.USER_ATTACHMENT_URL}/${this.props.profileImagePath}`;
   }
 
   createRequestedUserConnection(

--- a/src/features/user/dtos/response/hydrated-user.response-dto.ts
+++ b/src/features/user/dtos/response/hydrated-user.response-dto.ts
@@ -6,6 +6,7 @@ import {
 
 export interface CreateHydratedUserProps extends CreateBaseResponseDtoProps {
   nickname: string;
+  profileImageUrl: string;
 }
 
 export class HydratedUserResponseDto
@@ -20,9 +21,16 @@ export class HydratedUserResponseDto
   })
   readonly nickname: string;
 
+  @ApiProperty({
+    description: '유저 프로필 이미지 url',
+    format: 'uri',
+  })
+  readonly profileImageUrl: string;
+
   constructor(props: CreateHydratedUserProps) {
     super(props);
 
     this.nickname = props.nickname;
+    this.profileImageUrl = props.profileImageUrl;
   }
 }

--- a/src/features/user/dtos/response/user.response-dto.ts
+++ b/src/features/user/dtos/response/user.response-dto.ts
@@ -15,6 +15,7 @@ export interface CreateUserResponseDtoProps extends CreateBaseResponseDtoProps {
   loginType: UserLoginTypeUnion;
   mbti: UserMbtiUnion | null;
   isEmailVerified: boolean;
+  profileImageUrl: string;
 }
 
 export class UserResponseDto
@@ -59,15 +60,29 @@ export class UserResponseDto
   })
   readonly isEmailVerified: boolean;
 
+  @ApiProperty({
+    description: '유저 프로필 이미지 url',
+    format: 'uri',
+  })
+  readonly profileImageUrl: string;
+
   constructor(create: CreateUserResponseDtoProps) {
     super(create);
 
-    const { nickname, email, loginType, mbti, isEmailVerified } = create;
+    const {
+      nickname,
+      email,
+      loginType,
+      mbti,
+      isEmailVerified,
+      profileImageUrl,
+    } = create;
 
     this.nickname = nickname;
     this.email = email;
     this.loginType = loginType;
     this.mbti = mbti;
     this.isEmailVerified = isEmailVerified;
+    this.profileImageUrl = profileImageUrl;
   }
 }

--- a/src/features/user/mappers/user.mapper.ts
+++ b/src/features/user/mappers/user.mapper.ts
@@ -28,6 +28,7 @@ export const userSchema = baseSchema.extend({
   loginType: z.nativeEnum(UserLoginType),
   role: z.nativeEnum(UserRole),
   isEmailVerified: z.boolean(),
+  profileImagePath: z.string().min(1).max(255),
   mbti: z.nativeEnum(UserMbti).nullable(),
   deletedAt: z.preprocess(
     (val: any) => (val === null ? null : new Date(val)),
@@ -64,6 +65,7 @@ export class UserMapper
         role: record.role,
         mbti: record.mbti,
         isEmailVerified: record.isEmailVerified,
+        profileImagePath: record.profileImagePath,
         deletedAt: record.deletedAt,
         email: record.email,
         password: record.password,
@@ -115,6 +117,9 @@ export class UserMapper
   toResponseDto(entity: UserEntity): UserResponseDto {
     const props = entity.getProps();
 
-    return new UserResponseDto(props);
+    return new UserResponseDto({
+      ...props,
+      profileImageUrl: entity.profileImageUrl,
+    });
   }
 }

--- a/src/features/user/queries/find-one-user/find-one-user.query-handler.ts
+++ b/src/features/user/queries/find-one-user/find-one-user.query-handler.ts
@@ -6,6 +6,7 @@ import { isNil } from '@libs/utils/util';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { FindOneUserQuery } from '@features/user/queries/find-one-user/find-one-user.query';
+import { UserEntity } from '@features/user/domain/user.entity';
 
 @QueryHandler(FindOneUserQuery)
 export class FindOneUserQueryHandler
@@ -32,6 +33,9 @@ export class FindOneUserQueryHandler
       });
     }
 
-    return user;
+    return {
+      ...user,
+      profileImageUrl: `${UserEntity.USER_ATTACHMENT_URL}/${user.profileImagePath}`,
+    };
   }
 }

--- a/src/features/user/user-connection/dtos/response/user-connection.response-dto.ts
+++ b/src/features/user/user-connection/dtos/response/user-connection.response-dto.ts
@@ -7,8 +7,6 @@ import {
   CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
 import { AggregateID } from '@libs/ddd/entity.base';
-import { HydratedBlogResponseDto } from '@features/blog/dtos/response/hydrated-blog.response-dto';
-import { HydratedChatRoomResponseDto } from '@features/chat-room/dtos/response/hydrated-chat-room.response-dto';
 
 export interface CreateUserConnectionResponseDtoProps
   extends CreateBaseResponseDtoProps {
@@ -17,9 +15,6 @@ export interface CreateUserConnectionResponseDtoProps
   requestedId: AggregateID;
   requested?: HydratedUserResponseDto;
   status: UserConnectionStatusUnion;
-
-  blog?: HydratedBlogResponseDto;
-  chatRoom?: HydratedChatRoomResponseDto;
 }
 
 export class UserConnectionResponseDto
@@ -60,39 +55,15 @@ export class UserConnectionResponseDto
   })
   status: UserConnectionStatusUnion;
 
-  @ApiPropertyOptional({
-    description:
-      '블로그 정보. 해당 프로퍼티가 falsy한 값일 경우 블로그가 존재하지 않음.',
-    type: HydratedBlogResponseDto,
-  })
-  blog?: HydratedBlogResponseDto;
-
-  @ApiPropertyOptional({
-    description:
-      '채팅방 정보. 해당 프로퍼티가 falsy한 값일 경우 채팅방이 존재하지 않음.',
-    type: HydratedChatRoomResponseDto,
-  })
-  chatRoom?: HydratedChatRoomResponseDto;
-
   constructor(props: CreateUserConnectionResponseDtoProps) {
     super(props);
 
-    const {
-      requester,
-      requesterId,
-      requested,
-      requestedId,
-      status,
-      blog,
-      chatRoom,
-    } = props;
+    const { requester, requesterId, requested, requestedId, status } = props;
 
     this.requester = requester;
     this.requesterId = requesterId.toString();
     this.requested = requested;
     this.requestedId = requestedId.toString();
     this.status = status;
-    this.blog = blog;
-    this.chatRoom = chatRoom;
   }
 }

--- a/src/features/user/user-connection/mappers/user-connection.mapper.ts
+++ b/src/features/user/user-connection/mappers/user-connection.mapper.ts
@@ -14,8 +14,6 @@ import {
 } from '@features/user/user-connection/dtos/response/user-connection.response-dto';
 import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
 import { UserConnectionProps } from '@features/user/user-connection/domain/user-connection.entity-interface';
-import { HydratedBlogResponseDto } from '@features/blog/dtos/response/hydrated-blog.response-dto';
-import { HydratedChatRoomResponseDto } from '@features/chat-room/dtos/response/hydrated-chat-room.response-dto';
 import { isNil } from '@libs/utils/util';
 
 export const userConnectionSchema = baseSchema.extend({
@@ -93,29 +91,11 @@ export class UserConnectionMapper
   }
 
   toResponseDto(entity: UserConnectionEntity): UserConnectionResponseDto {
-    const { blog, requestedUser, requesterUser, chatRoom, ...props } =
-      entity.getProps();
+    const { requestedUser, requesterUser, ...props } = entity.getProps();
 
     const createDtoProps: CreateUserConnectionResponseDtoProps = {
       ...props,
     };
-
-    if (!isNil(blog)) {
-      createDtoProps.blog = new HydratedBlogResponseDto({
-        id: blog.id,
-        name: blog.name,
-        createdAt: blog.createdAt,
-        updatedAt: blog.updatedAt,
-      });
-    }
-
-    if (!isNil(chatRoom)) {
-      createDtoProps.chatRoom = new HydratedChatRoomResponseDto({
-        id: chatRoom.id,
-        createdAt: chatRoom.createdAt,
-        updatedAt: chatRoom.updatedAt,
-      });
-    }
 
     if (!isNil(requestedUser)) {
       createDtoProps.requested = new HydratedUserResponseDto({

--- a/src/features/user/user-connection/mappers/user-connection.mapper.ts
+++ b/src/features/user/user-connection/mappers/user-connection.mapper.ts
@@ -121,6 +121,7 @@ export class UserConnectionMapper
       createDtoProps.requested = new HydratedUserResponseDto({
         id: requestedUser.id,
         nickname: requestedUser.nickname,
+        profileImageUrl: requestedUser.profileImageUrl,
         createdAt: requestedUser.createdAt,
         updatedAt: requestedUser.updatedAt,
       });
@@ -130,6 +131,7 @@ export class UserConnectionMapper
       createDtoProps.requester = new HydratedUserResponseDto({
         id: requesterUser.id,
         nickname: requesterUser.nickname,
+        profileImageUrl: requesterUser.profileImageUrl,
         createdAt: requesterUser.createdAt,
         updatedAt: requesterUser.updatedAt,
       });

--- a/src/libs/core/app-config/app-config.module.ts
+++ b/src/libs/core/app-config/app-config.module.ts
@@ -46,6 +46,11 @@ import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.
         [ENV_KEY.AWS_S3_REGION]: Joi.string().required(),
         [ENV_KEY.AWS_S3_BUCKET]: Joi.string().required(),
         [ENV_KEY.AWS_S3_BUCKET_URL]: Joi.string().required(),
+
+        [ENV_KEY.USER_ATTACHMENT_URL]: Joi.string().required(),
+        [ENV_KEY.USER_DEFAULT_PROFILE_IMAGE_PATH]: Joi.string().required(),
+
+        [ENV_KEY.BLOG_ATTACHMENT_URL]: Joi.string().required(),
       }),
     }),
   ],

--- a/src/libs/core/app-config/constants/app-config.constant.ts
+++ b/src/libs/core/app-config/constants/app-config.constant.ts
@@ -39,6 +39,15 @@ const AWS = {
   AWS_S3_BUCKET_URL: 'AWS_S3_BUCKET_URL',
 } as const;
 
+const USER = {
+  USER_ATTACHMENT_URL: 'USER_ATTACHMENT_URL',
+  USER_DEFAULT_PROFILE_IMAGE_PATH: 'USER_DEFAULT_PROFILE_IMAGE_PATH',
+} as const;
+
+const BLOG = {
+  BLOG_ATTACHMENT_URL: 'BLOG_ATTACHMENT_URL',
+} as const;
+
 /**
  * 각 주제에 맞게 묶어서 export 하지 않는 변수로 생성하고
  * ENV_KEY 객체에 spread
@@ -50,4 +59,6 @@ export const ENV_KEY = {
   ...EMAIL,
   ...DATABASE,
   ...AWS,
+  ...USER,
+  ...BLOG,
 } as const;

--- a/src/libs/s3/services/s3.service.ts
+++ b/src/libs/s3/services/s3.service.ts
@@ -78,7 +78,7 @@ export class S3Service implements S3ServicePort {
           };
     } = {};
 
-    const deleteKeys: string[] = [];
+    // const deleteKeys: string[] = [];
 
     await Promise.all(
       /**
@@ -106,7 +106,7 @@ export class S3Service implements S3ServicePort {
             )}/${newPath}`,
           };
 
-          deleteKeys.push(source);
+          // deleteKeys.push(source);
         } catch (err) {
           if (err instanceof S3ServiceException) {
             if (
@@ -123,7 +123,7 @@ export class S3Service implements S3ServicePort {
       }),
     );
 
-    await this.deleteFilesFromS3(deleteKeys);
+    // await this.deleteFilesFromS3(deleteKeys);
 
     return sourcePathInfosObject;
   }


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#116 

<!-- 내용 (필수) -->

### Description

유저에선 이미지, 블로그에선 이미지(뒷배경), 소개, Dday를 추가했습니다.
그에 따라 관련 로직도 추가됐습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer

유저의 프로필 이미지는 가입 이후 프로필 수정 시에 추가할 수 있고, default 이미지가 있습니다.
블로그의 경우엔 뒷 배경은 optional한 값입니다.

### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| GET    | /api/user | 유저 정보 조회 | 추가                   |
