### PR TITLE
블로그 PATCH Update API 추가

### DIFF
--- a/prisma/migrations/20250212033536_create_nullable_profile_image_path/migration.sql
+++ b/prisma/migrations/20250212033536_create_nullable_profile_image_path/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "profile_image_path" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,7 @@ model User {
   loginType        LoginTypeEnum @map("login_type")
   role             UserRoleEnum  @default(USER)
   isEmailVerified  Boolean       @default(false) @map("is_email_verified") @db.Boolean
-  profileImagePath String        @map("profile_image_path") @db.VarChar(255)
+  profileImagePath String?       @map("profile_image_path") @db.VarChar(255)
   mbti             MbtiEnum?
   createdAt        DateTime      @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt        DateTime      @default(now()) @map("updated_at") @db.Timestamptz(6)

--- a/src/configs/app.route.ts
+++ b/src/configs/app.route.ts
@@ -37,6 +37,7 @@ export const routesV1 = {
     root: blogRoot,
     create: `${blogRoot}`,
     findOneByUserId: `${userRoot}/:id/blog`,
+    patchUpdate: `${blogRoot}/:id`,
   },
 
   blogPost: {

--- a/src/features/blog-post/dtos/request/create-blog-post.request-body-dto.ts
+++ b/src/features/blog-post/dtos/request/create-blog-post.request-body-dto.ts
@@ -75,6 +75,7 @@ export class CreateBlogPostRequestBodyDto {
     default: [],
     uniqueItems: true,
   })
+  @Length(1, 20, { each: true })
   @ArrayUnique()
   fileUrls: string[] = [];
 }

--- a/src/features/blog-post/dtos/response/blog-post.response-dto.ts
+++ b/src/features/blog-post/dtos/response/blog-post.response-dto.ts
@@ -27,12 +27,14 @@ export class BlogPostResponseDto
   @ApiProperty({
     format: 'int64',
     description: '블로그 생성 유저 ID',
+    type: 'string',
   })
   readonly userId: AggregateID;
 
   @ApiProperty({
     format: 'int64',
     description: '블로그 ID',
+    type: 'string',
   })
   readonly blogId: AggregateID;
 

--- a/src/features/blog/blog.module.ts
+++ b/src/features/blog/blog.module.ts
@@ -1,5 +1,6 @@
 import { AttachmentModule } from '@features/attachment/attachment.module';
 import { CreateBlogCommandHandler } from '@features/blog/commands/create-blog/create-blog.command-handler';
+import { PatchUpdateBlogCommandHandler } from '@features/blog/commands/patch-update-blog/patch-update-blog.command-handler';
 import { BlogController } from '@features/blog/controllers/blog.controller';
 import { BlogMapper } from '@features/blog/mappers/blog.mapper';
 import { FindOneBlogByUserIdQueryHandler } from '@features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler';
@@ -14,7 +15,10 @@ const controllers = [BlogController];
 
 const mappers: Provider[] = [BlogMapper];
 
-const commandHandlers: Provider[] = [CreateBlogCommandHandler];
+const commandHandlers: Provider[] = [
+  CreateBlogCommandHandler,
+  PatchUpdateBlogCommandHandler,
+];
 
 const queryHandlers: Provider[] = [FindOneBlogByUserIdQueryHandler];
 

--- a/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
+++ b/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
@@ -19,6 +19,7 @@ import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-c
 import { S3ServicePort } from '@libs/s3/services/s3.service-port';
 import { S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
 import { isNil } from '@libs/utils/util';
+import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { getTsid } from 'tsid-ts';
@@ -38,6 +39,7 @@ export class PatchUpdateBlogCommandHandler
     private readonly attachmentRepository: AttachmentRepositoryPort,
   ) {}
 
+  @Transactional()
   async execute(command: PatchUpdateBlogCommand): Promise<void> {
     const {
       userId,

--- a/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
+++ b/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
@@ -1,0 +1,147 @@
+import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { Location } from '@features/attachment/domain/value-objects/location.value-object';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
+import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
+import { PatchUpdateBlogCommand } from '@features/blog/commands/patch-update-blog/patch-update-blog.command';
+import { BlogEntity } from '@features/blog/domain/blog.entity';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
+import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
+import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
+import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
+import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
+import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
+import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
+import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
+import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
+import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
+import { S3ServicePort } from '@libs/s3/services/s3.service-port';
+import { S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
+import { isNil } from '@libs/utils/util';
+import { Inject } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { getTsid } from 'tsid-ts';
+
+@CommandHandler(PatchUpdateBlogCommand)
+export class PatchUpdateBlogCommandHandler
+  implements ICommandHandler<PatchUpdateBlogCommand, void>
+{
+  constructor(
+    @Inject(BLOG_REPOSITORY_DI_TOKEN)
+    private readonly blogRepository: BlogRepositoryPort,
+    @Inject(USER_CONNECTION_REPOSITORY_DI_TOKEN)
+    private readonly userConnectionRepository: UserConnectionRepositoryPort,
+    @Inject(S3_SERVICE_DI_TOKEN)
+    private readonly s3Service: S3ServicePort,
+    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly attachmentRepository: AttachmentRepositoryPort,
+  ) {}
+
+  async execute(command: PatchUpdateBlogCommand): Promise<void> {
+    const {
+      userId,
+      blogId,
+      backgroundImageFile,
+      name,
+      description,
+      dDayStartDate,
+    } = command;
+
+    if ([backgroundImageFile, name, description, dDayStartDate].every(isNil)) {
+      throw new HttpBadRequestException({
+        code: COMMON_ERROR_CODE.MISSING_UPDATE_FIELD,
+      });
+    }
+
+    const blog = await this.blogRepository.findOneById(blogId);
+
+    if (isNil(blog)) {
+      throw new HttpNotFoundException({
+        code: COMMON_ERROR_CODE.RESOURCE_NOT_FOUND,
+      });
+    }
+
+    const userConnection =
+      await this.userConnectionRepository.findOneByIdAndStatus(
+        blog.connectionId,
+        UserConnectionStatus.ACCEPTED,
+      );
+
+    if (isNil(userConnection)) {
+      throw new HttpInternalServerErrorException({
+        code: COMMON_ERROR_CODE.SERVER_ERROR,
+        ctx: '블로그가 존재하는데 유저 커넥션이 존재하지 않는 것은 에러',
+      });
+    }
+
+    if (!userConnection.isPartOfConnection(userId)) {
+      throw new HttpForbiddenException({
+        code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
+      });
+    }
+
+    if (!isNil(description)) {
+      blog.editDescription(description);
+    }
+
+    if (!isNil(dDayStartDate)) {
+      blog.editDDayStartDate(dDayStartDate);
+    }
+
+    if (!isNil(name)) {
+      blog.editName(name);
+    }
+
+    if (!isNil(backgroundImageFile)) {
+      /**
+       * @todo 현재 파일에 관련한 중복 로직이 많음.
+       * 또한 현재 Attachment를 생성하는 방식은 CreateAttachmentHandler
+       * 혹은 각 도메인의 핸들러에서 외부의 AggregateRoot인 Attachment를 생성해주는데
+       * Attachment 관련한 작업의 중복 제거를 위함 및
+       * Attachment의 LifeCycle에 관한 책임을 갖고 있는 중간 다리 역할인 AttachmentService가 필요해 보임.
+       * 추후에 수정 필요.
+       */
+      const { mimeType, capacity, buffer } = backgroundImageFile;
+
+      const id = getTsid().toBigInt();
+      const path = BlogEntity.BLOG_BACKGROUND_IMAGE_PATH_PREFIX + id;
+
+      const url = await this.s3Service.uploadFileToS3(
+        {
+          buffer: buffer,
+          mimetype: mimeType,
+        },
+        path,
+      );
+
+      try {
+        const attachment = AttachmentEntity.create({
+          id,
+          userId,
+          capacity: BigInt(capacity),
+          mimeType,
+          uploadType: AttachmentUploadType.FILE,
+          location: new Location({
+            path,
+            url,
+          }),
+        });
+
+        await this.attachmentRepository.create(attachment);
+
+        blog.editBackgroundImagePath(path);
+      } catch (error: any) {
+        await this.s3Service.deleteFilesFromS3([path]);
+
+        throw new HttpInternalServerErrorException({
+          code: COMMON_ERROR_CODE.SERVER_ERROR,
+          ctx: 'Failed files upload',
+          stack: error.stack,
+        });
+      }
+    }
+
+    await this.blogRepository.update(blog);
+  }
+}

--- a/src/features/blog/commands/patch-update-blog/patch-update-blog.command.ts
+++ b/src/features/blog/commands/patch-update-blog/patch-update-blog.command.ts
@@ -9,7 +9,7 @@ export class PatchUpdateBlogCommand extends Command implements ICommand {
     buffer: Buffer;
     capacity: number;
     mimeType: string;
-  };
+  } | null;
   readonly name?: string;
   readonly description?: string;
   readonly dDayStartDate?: string;

--- a/src/features/blog/commands/patch-update-blog/patch-update-blog.command.ts
+++ b/src/features/blog/commands/patch-update-blog/patch-update-blog.command.ts
@@ -1,0 +1,27 @@
+import { Command, CommandProps } from '@libs/ddd/command.base';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
+
+export class PatchUpdateBlogCommand extends Command implements ICommand {
+  readonly userId: AggregateID;
+  readonly blogId: AggregateID;
+  readonly backgroundImageFile?: {
+    buffer: Buffer;
+    capacity: number;
+    mimeType: string;
+  };
+  readonly name?: string;
+  readonly description?: string;
+  readonly dDayStartDate?: string;
+
+  constructor(props: CommandProps<PatchUpdateBlogCommand>) {
+    super(props);
+
+    this.userId = props.userId;
+    this.blogId = props.blogId;
+    this.backgroundImageFile = props.backgroundImageFile;
+    this.name = props.name;
+    this.description = props.description;
+    this.dDayStartDate = props.dDayStartDate;
+  }
+}

--- a/src/features/blog/controllers/blog.controller.ts
+++ b/src/features/blog/controllers/blog.controller.ts
@@ -119,7 +119,9 @@ export class BlogController {
             capacity: backgroundImageFile.size,
             buffer: backgroundImageFile.buffer,
           }
-        : undefined,
+        : backgroundImageFile === null
+          ? null
+          : undefined,
     });
 
     await this.commandBus.execute(command);

--- a/src/features/blog/controllers/blog.controller.ts
+++ b/src/features/blog/controllers/blog.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { CreateBlogCommand } from '@features/blog/commands/create-blog/create-blog.command';
@@ -18,6 +27,8 @@ import { SetGuardType } from '@libs/guards/decorators/set-guard-type.decorator';
 import { GuardType } from '@libs/guards/types/guard.constant';
 import { ParsePositiveBigIntPipe } from '@libs/api/pipes/parse-positive-int.pipe';
 import { FormDataRequest } from 'nestjs-form-data';
+import { PatchUpdateBlogRequestBodyDto } from '@features/blog/dtos/request/patch-update-blog.request-body-dto';
+import { PatchUpdateBlogCommand } from '@features/blog/commands/patch-update-blog/patch-update-blog.command';
 
 @ApiTags('Blog')
 @ApiInternalServerErrorBuilder()
@@ -83,5 +94,34 @@ export class BlogController {
         (member) => new HydratedUserResponseDto(member),
       ),
     });
+  }
+
+  @ApiBlog.PatchUpdate({
+    summary: '블로그 정보 PatchUpdate API',
+  })
+  @FormDataRequest()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Patch(routesV1.blog.patchUpdate)
+  async patchUpdate(
+    @User('sub') userId: AggregateID,
+    @Param('id', ParsePositiveBigIntPipe) blogId: string,
+    @Body() requestBodyDto: PatchUpdateBlogRequestBodyDto,
+  ): Promise<void> {
+    const { backgroundImageFile, ...rest } = requestBodyDto;
+
+    const command = new PatchUpdateBlogCommand({
+      userId,
+      blogId: BigInt(blogId),
+      ...rest,
+      backgroundImageFile: backgroundImageFile
+        ? {
+            mimeType: backgroundImageFile.mimeType,
+            capacity: backgroundImageFile.size,
+            buffer: backgroundImageFile.buffer,
+          }
+        : undefined,
+    });
+
+    await this.commandBus.execute(command);
   }
 }

--- a/src/features/blog/controllers/blog.swagger.ts
+++ b/src/features/blog/controllers/blog.swagger.ts
@@ -175,7 +175,6 @@ export const ApiBlog: ApiOperator<keyof BlogController> = {
       }),
       ApiBearerAuth('access-token'),
       ApiConsumes('multipart/form-data'),
-      ApiConsumes('multipart/form-data'),
       ApiBody({
         description:
           'Mime-Type은 image/png, image/jpeg 타입만 허용됨.<br>' +
@@ -186,6 +185,9 @@ export const ApiBlog: ApiOperator<keyof BlogController> = {
             backgroundImageFile: {
               type: 'string',
               format: 'binary',
+              nullable: true,
+              description:
+                '블로그 배경 이미지 파일. empty string을 보낼 경우 null로 판단해 배경 사진을 아예 삭제함.',
             },
             name: {
               description: '블로그 이름',

--- a/src/features/blog/controllers/blog.swagger.ts
+++ b/src/features/blog/controllers/blog.swagger.ts
@@ -4,6 +4,7 @@ import {
   ApiBody,
   ApiConsumes,
   ApiCreatedResponse,
+  ApiNoContentResponse,
   ApiOkResponse,
   ApiOperation,
 } from '@nestjs/swagger';
@@ -154,6 +155,93 @@ export const ApiBlog: ApiOperator<keyof BlogController> = {
             ],
             errorType: CustomValidationError,
           },
+        },
+      ]),
+      HttpNotFoundException.swaggerBuilder(HttpStatus.NOT_FOUND, [
+        {
+          code: COMMON_ERROR_CODE.RESOURCE_NOT_FOUND,
+          description: '블로그가 존재하지 않음.',
+        },
+      ]),
+    );
+  },
+
+  PatchUpdate: (
+    apiOperationOptions: ApiOperationOptionsWithSummary,
+  ): MethodDecorator => {
+    return applyDecorators(
+      ApiOperation({
+        ...apiOperationOptions,
+      }),
+      ApiBearerAuth('access-token'),
+      ApiConsumes('multipart/form-data'),
+      ApiConsumes('multipart/form-data'),
+      ApiBody({
+        description:
+          'Mime-Type은 image/png, image/jpeg 타입만 허용됨.<br>' +
+          '파일 크기는 10MB 까지만 허용됨.',
+        schema: {
+          type: 'object',
+          properties: {
+            backgroundImageFile: {
+              type: 'string',
+              format: 'binary',
+            },
+            name: {
+              description: '블로그 이름',
+              type: 'string',
+              minLength: 1,
+              maxLength: 30,
+            },
+            description: {
+              description: '블로그 설명',
+              type: 'string',
+              minLength: 1,
+              maxLength: 255,
+            },
+            dDayStartDate: {
+              description:
+                '블로그 시작일. 시간 제외 날짜 값까지만 허용. ex)2025-02-06',
+              type: 'string',
+              format: 'date',
+              maxLength: 10,
+            },
+          },
+        },
+      }),
+      ApiNoContentResponse({
+        description: '정상적으로 블로그 수정됨.',
+      }),
+      HttpBadRequestException.swaggerBuilder(HttpStatus.BAD_REQUEST, [
+        {
+          code: COMMON_ERROR_CODE.INVALID_REQUEST_PARAMETER,
+          description: 'name의 길이가 1 이상 30 이하가 아님. 외 기타 등등',
+          additionalErrors: {
+            errors: [
+              {
+                property: 'name',
+                value: 'qwdqwdqwasdasdasdasdasdasdasdasdasdadas',
+                reason: 'name must be shorter than or equal to 30 characters',
+              },
+            ],
+            errorType: CustomValidationError,
+          },
+        },
+        {
+          code: COMMON_ERROR_CODE.MISSING_UPDATE_FIELD,
+          description: '수정할 필드가 하나도 없음.',
+        },
+      ]),
+      HttpUnauthorizedException.swaggerBuilder(HttpStatus.UNAUTHORIZED, [
+        {
+          code: COMMON_ERROR_CODE.INVALID_TOKEN,
+          description: '유효하지 않은 토큰으로 인해서 발생하는 에러.',
+        },
+      ]),
+      HttpForbiddenException.swaggerBuilder(HttpStatus.FORBIDDEN, [
+        {
+          code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
+          description: '유저가 커넥션의 속하지 않음.',
         },
       ]),
       HttpNotFoundException.swaggerBuilder(HttpStatus.NOT_FOUND, [

--- a/src/features/blog/domain/blog.entity.ts
+++ b/src/features/blog/domain/blog.entity.ts
@@ -68,6 +68,56 @@ export class BlogEntity extends AggregateRoot<BlogProps> {
       : null;
   }
 
+  editName(name: string) {
+    if (!Guard.lengthIsBetween(name, 1, 30)) {
+      throw new HttpInternalServerErrorException({
+        code: COMMON_ERROR_CODE.SERVER_ERROR,
+        ctx: 'name must be between 1 and 30 characters',
+      });
+    }
+
+    this.props.name = name;
+  }
+
+  editDescription(description: string) {
+    if (!Guard.lengthIsBetween(description, 1, 255)) {
+      throw new HttpInternalServerErrorException({
+        code: COMMON_ERROR_CODE.SERVER_ERROR,
+        ctx: 'description must be between 1 and 255 characters',
+      });
+    }
+
+    this.props.description = description;
+  }
+
+  editBackgroundImagePath(backgroundImagePath: string) {
+    if (
+      !backgroundImagePath.startsWith(
+        BlogEntity.BLOG_BACKGROUND_IMAGE_PATH_PREFIX,
+      )
+    ) {
+      throw new HttpInternalServerErrorException({
+        code: COMMON_ERROR_CODE.SERVER_ERROR,
+        ctx:
+          'backgroundImagePath must start with ' +
+          BlogEntity.BLOG_BACKGROUND_IMAGE_PATH_PREFIX,
+      });
+    }
+
+    this.props.backgroundImagePath = backgroundImagePath;
+  }
+
+  editDDayStartDate(dDayStartDate: string) {
+    if (!Guard.lengthIsBetween(dDayStartDate, 1, 20)) {
+      throw new HttpInternalServerErrorException({
+        code: COMMON_ERROR_CODE.SERVER_ERROR,
+        ctx: 'dDayStartDate must be between 1 and 20 characters',
+      });
+    }
+
+    this.props.dDayStartDate = dDayStartDate;
+  }
+
   hydrateMember(user: UserEntity) {
     (this.props.members = this.props.members ?? []).push(user.hydrateProps);
   }

--- a/src/features/blog/domain/blog.entity.ts
+++ b/src/features/blog/domain/blog.entity.ts
@@ -12,6 +12,7 @@ import { AggregateRoot } from '@libs/ddd/aggregate-root.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { UserEntity } from '@features/user/domain/user.entity';
 import { HydratedUserEntityProps } from '@features/user/domain/user.entity-interface';
+import { isNil } from '@libs/utils/util';
 
 export class BlogEntity extends AggregateRoot<BlogProps> {
   static readonly BLOG_ATTACHMENT_URL = process.env.BLOG_ATTACHMENT_URL;
@@ -62,9 +63,13 @@ export class BlogEntity extends AggregateRoot<BlogProps> {
     return this.props.members || null;
   }
 
+  get backgroundImagePath(): string | null {
+    return this.props.backgroundImagePath;
+  }
+
   get backgroundImageUrl(): string | null {
-    return this.props.backgroundImagePath
-      ? BlogEntity.BLOG_ATTACHMENT_URL + this.props.backgroundImagePath
+    return this.backgroundImagePath
+      ? `${BlogEntity.BLOG_ATTACHMENT_URL}/${this.backgroundImagePath}`
       : null;
   }
 
@@ -90,8 +95,9 @@ export class BlogEntity extends AggregateRoot<BlogProps> {
     this.props.description = description;
   }
 
-  editBackgroundImagePath(backgroundImagePath: string) {
+  editBackgroundImagePath(backgroundImagePath: string | null) {
     if (
+      !isNil(backgroundImagePath) &&
       !backgroundImagePath.startsWith(
         BlogEntity.BLOG_BACKGROUND_IMAGE_PATH_PREFIX,
       )

--- a/src/features/blog/dtos/request/patch-update-blog.request-body-dto.ts
+++ b/src/features/blog/dtos/request/patch-update-blog.request-body-dto.ts
@@ -9,16 +9,21 @@ import {
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
 import { IsOptional } from 'class-validator';
 import { BlogEntity } from '@features/blog/domain/blog.entity';
+import { IsNullable } from '@libs/api/decorators/is-nullable.decorator';
+import { Transform } from 'class-transformer';
 
 export class PatchUpdateBlogRequestBodyDto extends PartialType(
   OmitType(CreateBlogRequestBodyDto, ['backgroundImageFile'] as const),
 ) {
   @ApiPropertyOptional({
-    description: '유저 프로필 이미지 파일',
+    description:
+      '블로그 배경 이미지 파일. empty string일 경우 null로 판단해 배경 사진을 아예 삭제함.',
   })
   @IsFile()
   @HasMimeType([...BlogEntity.BLOG_BACKGROUND_IMAGE_MIME_TYPE])
   @MaxFileSize(AttachmentEntity.ATTACHMENT_CAPACITY_MAX)
   @IsOptional()
-  backgroundImageFile?: MemoryStoredFile;
+  @IsNullable()
+  @Transform(({ value }) => (value === '' ? null : value))
+  backgroundImageFile?: MemoryStoredFile | null;
 }

--- a/src/features/blog/dtos/request/patch-update-blog.request-body-dto.ts
+++ b/src/features/blog/dtos/request/patch-update-blog.request-body-dto.ts
@@ -1,0 +1,24 @@
+import { ApiPropertyOptional, OmitType, PartialType } from '@nestjs/swagger';
+import { CreateBlogRequestBodyDto } from '@features/blog/dtos/request/create-blog.request-body-dto';
+import {
+  HasMimeType,
+  IsFile,
+  MaxFileSize,
+  MemoryStoredFile,
+} from 'nestjs-form-data';
+import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { IsOptional } from 'class-validator';
+import { BlogEntity } from '@features/blog/domain/blog.entity';
+
+export class PatchUpdateBlogRequestBodyDto extends PartialType(
+  OmitType(CreateBlogRequestBodyDto, ['backgroundImageFile'] as const),
+) {
+  @ApiPropertyOptional({
+    description: '유저 프로필 이미지 파일',
+  })
+  @IsFile()
+  @HasMimeType([...BlogEntity.BLOG_BACKGROUND_IMAGE_MIME_TYPE])
+  @MaxFileSize(AttachmentEntity.ATTACHMENT_CAPACITY_MAX)
+  @IsOptional()
+  backgroundImageFile?: MemoryStoredFile;
+}

--- a/src/features/blog/dtos/response/blog.response-dto.ts
+++ b/src/features/blog/dtos/response/blog.response-dto.ts
@@ -52,12 +52,14 @@ export class BlogResponseDto
   @ApiProperty({
     format: 'int64',
     description: '블로그 생성 유저 ID',
+    type: 'string',
   })
   readonly createdBy: AggregateID;
 
   @ApiProperty({
     format: 'int64',
     description: '유저 커넥션 ID',
+    type: 'string',
   })
   readonly connectionId: AggregateID;
 

--- a/src/features/chat-message/dtos/response/chat-message.response-dto.ts
+++ b/src/features/chat-message/dtos/response/chat-message.response-dto.ts
@@ -18,14 +18,16 @@ export class ChatMessageResponseDto
   implements Omit<CreateBaseResponseDtoProps, keyof CreateBaseResponseDtoProps>
 {
   @ApiProperty({
-    example: 668734709767935546n,
+    example: '668734709767935546',
     description: '채팅방 ID',
+    type: 'string',
   })
   readonly roomId: AggregateID;
 
   @ApiProperty({
-    example: 668734709767935546n,
+    example: '668734709767935546',
     description: '메시지를 보낸 유저 ID',
+    type: 'string',
   })
   readonly senderId: AggregateID;
 

--- a/src/features/chat-room/dtos/response/chat-room.response-dto.ts
+++ b/src/features/chat-room/dtos/response/chat-room.response-dto.ts
@@ -19,12 +19,14 @@ export class ChatRoomResponseDto
   @ApiProperty({
     format: 'int64',
     description: '채팅방 생성 유저 ID',
+    type: 'string',
   })
   readonly createdBy: AggregateID;
 
   @ApiProperty({
     format: 'int64',
     description: '유저 커넥션 ID',
+    type: 'string',
   })
   readonly connectionId: AggregateID;
 

--- a/src/features/user/application/event-handlers/create-user-email-verify-token.domain-event-handler.ts
+++ b/src/features/user/application/event-handlers/create-user-email-verify-token.domain-event-handler.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { OnEvent } from '@nestjs/event-emitter';
 import { UserCreatedDomainEvent } from '@features/user/domain/events/user-created.event';
 import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
@@ -7,6 +6,8 @@ import { EMAIL_SERVICE_DI_TOKEN } from '@libs/email/constants/email-service.di-t
 import { EmailServicePort } from '@libs/email/services/email.service-port';
 import { UserVerifyTokenEntity } from '@features/user/domain/user-verify-token/user-verify-token.entity';
 import { UserVerifyTokenType } from '@features/user/types/user.constant';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Propagation, Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class CreateUserEmailVerifyTokenDomainEventHandler {
@@ -19,9 +20,8 @@ export class CreateUserEmailVerifyTokenDomainEventHandler {
 
   @OnEvent(UserCreatedDomainEvent.name, {
     async: true,
-    promisify: true,
-    suppressErrors: false,
   })
+  @Transactional(Propagation.RequiresNew)
   async handle(event: UserCreatedDomainEvent): Promise<void> {
     const userVerifyToken = UserVerifyTokenEntity.create({
       userId: event.aggregateId,

--- a/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
+++ b/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
@@ -88,7 +88,7 @@ export class PatchUpdateUserCommandHandler
           mimeType,
           uploadType: AttachmentUploadType.FILE,
           location: new Location({
-            path: UserEntity.USER_PROFILE_IMAGE_PATH_PREFIX,
+            path,
             url,
           }),
         });

--- a/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
+++ b/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
@@ -14,6 +14,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { S3ServicePort } from '@libs/s3/services/s3.service-port';
 import { S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
 import { isNil } from '@libs/utils/util';
+import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { getTsid } from 'tsid-ts';
@@ -31,6 +32,7 @@ export class PatchUpdateUserCommandHandler
     private readonly attachmentRepository: AttachmentRepositoryPort,
   ) {}
 
+  @Transactional()
   async execute(command: PatchUpdateUserCommand): Promise<void> {
     const { userId, nickname, mbti, profileImageFile } = command;
 

--- a/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
+++ b/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
@@ -36,8 +36,6 @@ export class PatchUpdateUserCommandHandler
   async execute(command: PatchUpdateUserCommand): Promise<void> {
     const { userId, nickname, mbti, profileImageFile } = command;
 
-    console.log(command);
-
     if ([nickname, mbti, profileImageFile].every(isNil)) {
       throw new HttpBadRequestException({
         code: COMMON_ERROR_CODE.MISSING_UPDATE_FIELD,

--- a/src/features/user/commands/patch-update-user/patch-update-user.command.ts
+++ b/src/features/user/commands/patch-update-user/patch-update-user.command.ts
@@ -11,7 +11,7 @@ export class PatchUpdateUserCommand extends Command implements ICommand {
     mimeType: string;
     capacity: number;
     buffer: Buffer;
-  };
+  } | null;
 
   constructor(props: CommandProps<PatchUpdateUserCommand>) {
     super(props);

--- a/src/features/user/commands/send-verification-email/send-verification-email.command-handler.ts
+++ b/src/features/user/commands/send-verification-email/send-verification-email.command-handler.ts
@@ -12,6 +12,7 @@ import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-code.constant';
 import { isNil } from '@libs/utils/util';
+import { Transactional } from '@nestjs-cls/transactional';
 
 @CommandHandler(SendVerificationEmailCommand)
 export class SendVerificationEmailCommandHandler
@@ -24,6 +25,7 @@ export class SendVerificationEmailCommandHandler
     private readonly emailService: EmailServicePort,
   ) {}
 
+  @Transactional()
   async execute(command: SendVerificationEmailCommand): Promise<void> {
     const { userId } = command;
 

--- a/src/features/user/controllers/user.controller.ts
+++ b/src/features/user/controllers/user.controller.ts
@@ -180,7 +180,9 @@ export class UserController {
             capacity: profileImageFile.size,
             buffer: profileImageFile.buffer,
           }
-        : undefined,
+        : profileImageFile === null
+          ? null
+          : undefined,
     });
 
     await this.commandBus.execute(command);

--- a/src/features/user/controllers/user.swagger.ts
+++ b/src/features/user/controllers/user.swagger.ts
@@ -305,6 +305,9 @@ export const ApiUser: ApiOperator<keyof Omit<UserController, 'verifyEmail'>> = {
             profileImageFile: {
               type: 'string',
               format: 'binary',
+              nullable: true,
+              description:
+                '유저 프로필 이미지 파일. empty string을 보낼 경우 null로 판단해 프로필 이미지를 아예 삭제함.',
             },
             nickname: {
               description: '유저 닉네임',

--- a/src/features/user/domain/user.entity-interface.ts
+++ b/src/features/user/domain/user.entity-interface.ts
@@ -14,7 +14,7 @@ export interface UserProps {
   password: string;
   loginType: UserLoginTypeUnion;
   isEmailVerified: boolean;
-  profileImagePath: string;
+  profileImagePath: string | null;
   mbti: UserMbtiUnion | null;
   deletedAt: Date | null;
 
@@ -33,5 +33,5 @@ export interface CreateUserProps {
 
 export interface HydratedUserEntityProps extends BaseEntityProps {
   nickname: string;
-  profileImageUrl: string;
+  profileImageUrl: string | null;
 }

--- a/src/features/user/domain/user.entity.ts
+++ b/src/features/user/domain/user.entity.ts
@@ -128,8 +128,10 @@ export class UserEntity extends AggregateRoot<UserProps> {
     };
   }
 
-  get profileImageUrl(): string {
-    return `${UserEntity.USER_ATTACHMENT_URL}/${this.props.profileImagePath}`;
+  get profileImageUrl(): string | null {
+    return this.props.profileImagePath
+      ? `${UserEntity.USER_ATTACHMENT_URL}/${this.props.profileImagePath}`
+      : null;
   }
 
   createRequestedUserConnection(

--- a/src/features/user/domain/user.entity.ts
+++ b/src/features/user/domain/user.entity.ts
@@ -261,8 +261,9 @@ export class UserEntity extends AggregateRoot<UserProps> {
     this.props.mbti = mbti;
   }
 
-  editProfileImagePath(profileImagePath: string) {
+  editProfileImagePath(profileImagePath: string | null) {
     if (
+      !isNil(profileImagePath) &&
       !profileImagePath.startsWith(UserEntity.USER_PROFILE_IMAGE_PATH_PREFIX)
     ) {
       throw new HttpInternalServerErrorException({

--- a/src/features/user/domain/user.entity.ts
+++ b/src/features/user/domain/user.entity.ts
@@ -52,7 +52,7 @@ export class UserEntity extends AggregateRoot<UserProps> {
       role: UserRole.USER,
       isEmailVerified: false,
       deletedAt: null,
-      profileImagePath: `${UserEntity.USER_ATTACHMENT_URL}/${UserEntity.USER_DEFAULT_PROFILE_IMAGE_PATH}`,
+      profileImagePath: String(UserEntity.USER_DEFAULT_PROFILE_IMAGE_PATH),
     };
 
     const user = new UserEntity({ id, props });

--- a/src/features/user/dtos/request/patch-update-user.request-body-dto.ts
+++ b/src/features/user/dtos/request/patch-update-user.request-body-dto.ts
@@ -30,7 +30,9 @@ export class PatchUpdateUserRequestBodyDto {
   mbti?: UserMbtiUnion;
 
   @ApiPropertyOptional({
-    description: '유저 프로필 이미지 파일',
+    description:
+      '유저 프로필 이미지 파일. empty string을 보낼 경우 null로 판단해 프로필 이미지를 아예 삭제함.',
+    nullable: true,
   })
   @IsFile()
   @HasMimeType([...UserEntity.USER_PROFILE_IMAGE_MIME_TYPE])

--- a/src/features/user/dtos/request/patch-update-user.request-body-dto.ts
+++ b/src/features/user/dtos/request/patch-update-user.request-body-dto.ts
@@ -2,7 +2,9 @@ import { AttachmentEntity } from '@features/attachment/domain/attachment.entity'
 import { UserEntity } from '@features/user/domain/user.entity';
 import { UserMbti } from '@features/user/types/user.constant';
 import { UserMbtiUnion } from '@features/user/types/user.type';
+import { IsNullable } from '@libs/api/decorators/is-nullable.decorator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import { IsEnum, IsOptional, Length } from 'class-validator';
 import {
   HasMimeType,
@@ -34,5 +36,7 @@ export class PatchUpdateUserRequestBodyDto {
   @HasMimeType([...UserEntity.USER_PROFILE_IMAGE_MIME_TYPE])
   @MaxFileSize(AttachmentEntity.ATTACHMENT_CAPACITY_MAX)
   @IsOptional()
-  profileImageFile?: MemoryStoredFile;
+  @IsNullable()
+  @Transform(({ value }) => (value === '' ? null : value))
+  profileImageFile?: MemoryStoredFile | null;
 }

--- a/src/features/user/dtos/response/hydrated-user.response-dto.ts
+++ b/src/features/user/dtos/response/hydrated-user.response-dto.ts
@@ -6,7 +6,7 @@ import {
 
 export interface CreateHydratedUserProps extends CreateBaseResponseDtoProps {
   nickname: string;
-  profileImageUrl: string;
+  profileImageUrl: string | null;
 }
 
 export class HydratedUserResponseDto
@@ -24,8 +24,9 @@ export class HydratedUserResponseDto
   @ApiProperty({
     description: '유저 프로필 이미지 url',
     format: 'uri',
+    nullable: true,
   })
-  readonly profileImageUrl: string;
+  readonly profileImageUrl: string | null;
 
   constructor(props: CreateHydratedUserProps) {
     super(props);

--- a/src/features/user/dtos/response/user.response-dto.ts
+++ b/src/features/user/dtos/response/user.response-dto.ts
@@ -15,7 +15,7 @@ export interface CreateUserResponseDtoProps extends CreateBaseResponseDtoProps {
   loginType: UserLoginTypeUnion;
   mbti: UserMbtiUnion | null;
   isEmailVerified: boolean;
-  profileImageUrl: string;
+  profileImageUrl: string | null;
 }
 
 export class UserResponseDto
@@ -63,8 +63,9 @@ export class UserResponseDto
   @ApiProperty({
     description: '유저 프로필 이미지 url',
     format: 'uri',
+    nullable: true,
   })
-  readonly profileImageUrl: string;
+  readonly profileImageUrl: string | null;
 
   constructor(create: CreateUserResponseDtoProps) {
     super(create);

--- a/src/features/user/mappers/user.mapper.ts
+++ b/src/features/user/mappers/user.mapper.ts
@@ -28,7 +28,7 @@ export const userSchema = baseSchema.extend({
   loginType: z.nativeEnum(UserLoginType),
   role: z.nativeEnum(UserRole),
   isEmailVerified: z.boolean(),
-  profileImagePath: z.string().min(1).max(255),
+  profileImagePath: z.string().min(1).max(255).nullable(),
   mbti: z.nativeEnum(UserMbti).nullable(),
   deletedAt: z.preprocess(
     (val: any) => (val === null ? null : new Date(val)),

--- a/src/features/user/user-connection/dtos/response/user-connection.response-dto.ts
+++ b/src/features/user/user-connection/dtos/response/user-connection.response-dto.ts
@@ -34,8 +34,9 @@ export class UserConnectionResponseDto
   @ApiProperty({
     description: '요청자 아이디',
     format: 'int64',
+    type: 'string',
   })
-  requesterId: string;
+  requesterId: AggregateID;
 
   @ApiPropertyOptional({
     description: '요청 수신자 정보',
@@ -46,8 +47,9 @@ export class UserConnectionResponseDto
   @ApiProperty({
     description: '요청 수신자 아이디',
     format: 'int64',
+    type: 'string',
   })
-  requestedId: string;
+  requestedId: AggregateID;
 
   @ApiProperty({
     description: '요청 상태',
@@ -61,9 +63,9 @@ export class UserConnectionResponseDto
     const { requester, requesterId, requested, requestedId, status } = props;
 
     this.requester = requester;
-    this.requesterId = requesterId.toString();
+    this.requesterId = requesterId;
     this.requested = requested;
-    this.requestedId = requestedId.toString();
+    this.requestedId = requestedId;
     this.status = status;
   }
 }


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#128 
<!-- 내용 (필수) -->

### Description

블로그 PATCH Update API 추가했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer

그 외 자잘한 수정사항이 많은데
- 각 ResponseDto에서 AggregateID 타입인 프로퍼티들의 스웨거 명세가 integer 타입으로 명세되던 실수 string으로 보이도록 수정
- 유저 생성 시 이메일 전송하던 이벤트 핸들러를 유저 생성 Command와 별도의 트랜잭션 및 비동기로 처리하도록 수정
  - 유저 이메일 전송 이벤트 자체는 실패해도 상관이 없기 때문에 별도의 컨텍스트에서 처리해서 API 응답 지연시간 감소
- 유저 프로필 수정 API에서 에러 로직 수정
- 유저 프로필 이미지를 nullable로 만들고 프로필 수정 시 기존 이미지에 대한 삭제 로직 추가

### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| PATCH    | /api/v1/blogs/:id | 블로그 PATCH Update | 추가                   |