### PR TITLE
블로그 테이블 내에 memberIds 추가

### DIFF
--- a/prisma/migrations/20250213072042_add_member_ids_column_in_blogs/migration.sql
+++ b/prisma/migrations/20250213072042_add_member_ids_column_in_blogs/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "blogs" ADD COLUMN     "member_ids" BIGINT[];
+
+-- member_ids 컬럼 업데이트:
+UPDATE "blogs"
+SET "member_ids" = ARRAY[c."requester_id", c."requested_id"]
+FROM "user_connections" c
+WHERE "blogs"."connection_id" = c."id";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,7 @@ model Blog {
   id                  BigInt    @id(map: "pk_blogs")
   createdBy           BigInt    @map("created_by") @db.BigInt()
   connectionId        BigInt    @unique(map: "uq_blogs_connection_id") @map("connection_id") @db.BigInt()
+  memberIds           BigInt[]  @map("member_ids") @db.BigInt()
   name                String    @db.VarChar(30)
   description         String    @db.VarChar(255)
   dDayStartDate       String    @map("d_day_start_date") @db.VarChar(20)

--- a/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
@@ -69,7 +69,7 @@ export class CreateBlogPostCommandHandler
       });
     }
 
-    if (!blog.isMemberOfBlog(userId)) {
+    if (!blog.isMember(userId)) {
       throw new HttpForbiddenException({
         code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
       });

--- a/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
@@ -1,9 +1,7 @@
 import { Inject } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { AggregateID } from '@libs/ddd/entity.base';
-import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
-import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
@@ -12,11 +10,7 @@ import { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/rep
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
 import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_TAG_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-tag/tokens/di.token';
-import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
-import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
-import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
-import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { Transactional } from '@nestjs-cls/transactional';
 import { TAG_REPOSITORY_DI_TOKEN } from '@features/tag/tokens/di.token';
 import { TagRepositoryPort } from '@features/tag/repositories/tag.repository-port';
@@ -30,6 +24,8 @@ import { AttachmentEntity } from '@features/attachment/domain/attachment.entity'
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
 import { BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-attachment/tokens/di.token';
 import { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
+import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
+import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 
 @CommandHandler(CreateBlogPostCommand)
 export class CreateBlogPostCommandHandler
@@ -42,8 +38,6 @@ export class CreateBlogPostCommandHandler
     private readonly blogPostTagRepository: BlogPostTagRepositoryPort,
     @Inject(BLOG_POST_REPOSITORY_DI_TOKEN)
     private readonly blogPostRepository: BlogPostRepositoryPort,
-    @Inject(USER_CONNECTION_REPOSITORY_DI_TOKEN)
-    private readonly userConnectionRepository: UserConnectionRepositoryPort,
     @Inject(TAG_REPOSITORY_DI_TOKEN)
     private readonly tagRepository: TagRepositoryPort,
     @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
@@ -75,20 +69,7 @@ export class CreateBlogPostCommandHandler
       });
     }
 
-    const userConnection =
-      await this.userConnectionRepository.findOneByIdAndStatus(
-        blog.connectionId,
-        UserConnectionStatus.ACCEPTED,
-      );
-
-    if (isNil(userConnection)) {
-      throw new HttpInternalServerErrorException({
-        code: COMMON_ERROR_CODE.SERVER_ERROR,
-        ctx: 'blog가 존재하는 데 user connection이 존재하지 않을 수 없음.',
-      });
-    }
-
-    if (!userConnection.isPartOfConnection(userId)) {
+    if (!blog.isMemberOfBlog(userId)) {
       throw new HttpForbiddenException({
         code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
       });

--- a/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command-handler.ts
@@ -37,7 +37,7 @@ export class DeleteBlogPostCommandHandler
       });
     }
 
-    if (!blog.isMemberOfBlog(userId)) {
+    if (!blog.isMember(userId)) {
       throw new HttpForbiddenException({
         code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
       });

--- a/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command-handler.ts
@@ -5,10 +5,8 @@ import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
 import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
-import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
-import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { isNil } from '@libs/utils/util';
@@ -39,20 +37,7 @@ export class DeleteBlogPostCommandHandler
       });
     }
 
-    const userConnection =
-      await this.userConnectionRepository.findOneByIdAndStatus(
-        blog.connectionId,
-        UserConnectionStatus.ACCEPTED,
-      );
-
-    if (isNil(userConnection)) {
-      throw new HttpInternalServerErrorException({
-        code: COMMON_ERROR_CODE.SERVER_ERROR,
-        ctx: '블로그가 존재하는 데 커넥션이 존재하지 않는 것은 에러.',
-      });
-    }
-
-    if (!userConnection.isPartOfConnection(userId)) {
+    if (!blog.isMemberOfBlog(userId)) {
       throw new HttpForbiddenException({
         code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
       });

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
@@ -18,12 +18,10 @@ import { TagRepositoryPort } from '@features/tag/repositories/tag.repository-por
 import { TAG_REPOSITORY_DI_TOKEN } from '@features/tag/tokens/di.token';
 import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
 import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
-import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
-import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { S3ServicePort } from '@libs/s3/services/s3.service-port';
@@ -85,20 +83,7 @@ export class PatchUpdateBlogPostCommandHandler
       });
     }
 
-    const userConnection =
-      await this.userConnectionRepository.findOneByIdAndStatus(
-        blog.connectionId,
-        UserConnectionStatus.ACCEPTED,
-      );
-
-    if (isNil(userConnection)) {
-      throw new HttpInternalServerErrorException({
-        code: COMMON_ERROR_CODE.SERVER_ERROR,
-        ctx: '블로그가 존재하는데 ACCEPTED된 userConnection이 존재하지 않을 수 없음.',
-      });
-    }
-
-    if (!userConnection.isPartOfConnection(userId)) {
+    if (!blog.isMemberOfBlog(userId)) {
       throw new HttpForbiddenException({
         code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
       });

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
@@ -83,7 +83,7 @@ export class PatchUpdateBlogPostCommandHandler
       });
     }
 
-    if (!blog.isMemberOfBlog(userId)) {
+    if (!blog.isMember(userId)) {
       throw new HttpForbiddenException({
         code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
       });

--- a/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query-handler.ts
+++ b/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query-handler.ts
@@ -1,5 +1,4 @@
 import { FindBlogPostsFromBlogQuery } from '@features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query';
-import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { PrismaService } from '@libs/core/prisma/services/prisma.service';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
@@ -39,12 +38,6 @@ export class FindBlogPostsFromBlogQueryHandler
       where: {
         id: blogId,
         deletedAt: null,
-        connection: {
-          status: UserConnectionStatus.ACCEPTED,
-        },
-      },
-      include: {
-        connection: true,
       },
     });
 
@@ -56,8 +49,7 @@ export class FindBlogPostsFromBlogQueryHandler
 
     if (
       showPrivatePosts &&
-      blog.connection.requestedId !== userId &&
-      blog.connection.requesterId !== userId
+      (isNil(userId) || !blog.memberIds.includes(userId))
     ) {
       throw new HttpForbiddenException({
         code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,

--- a/src/features/blog/commands/create-blog/create-blog.command-handler.ts
+++ b/src/features/blog/commands/create-blog/create-blog.command-handler.ts
@@ -122,6 +122,10 @@ export class CreateBlogCommandHandler
       description,
       dDayStartDate,
       backgroundImagePath,
+      memberIds: [
+        acceptedConnection.requesterId,
+        acceptedConnection.requestedId,
+      ],
     });
 
     await this.blogRepository.create(blog);

--- a/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
+++ b/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
@@ -9,7 +9,6 @@ import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
 import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
-import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
@@ -64,20 +63,7 @@ export class PatchUpdateBlogCommandHandler
       });
     }
 
-    const userConnection =
-      await this.userConnectionRepository.findOneByIdAndStatus(
-        blog.connectionId,
-        UserConnectionStatus.ACCEPTED,
-      );
-
-    if (isNil(userConnection)) {
-      throw new HttpInternalServerErrorException({
-        code: COMMON_ERROR_CODE.SERVER_ERROR,
-        ctx: '블로그가 존재하는데 유저 커넥션이 존재하지 않는 것은 에러',
-      });
-    }
-
-    if (!userConnection.isPartOfConnection(userId)) {
+    if (!blog.isMemberOfBlog(userId)) {
       throw new HttpForbiddenException({
         code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
       });

--- a/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
+++ b/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
@@ -63,7 +63,7 @@ export class PatchUpdateBlogCommandHandler
       });
     }
 
-    if (!blog.isMemberOfBlog(userId)) {
+    if (!blog.isMember(userId)) {
       throw new HttpForbiddenException({
         code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
       });

--- a/src/features/blog/controllers/blog.controller.ts
+++ b/src/features/blog/controllers/blog.controller.ts
@@ -90,6 +90,7 @@ export class BlogController {
 
     return new BlogResponseDto({
       ...result,
+      memberIds: result.memberIds,
       members: result.members.map(
         (member) => new HydratedUserResponseDto(member),
       ),

--- a/src/features/blog/domain/blog.entity-interface.ts
+++ b/src/features/blog/domain/blog.entity-interface.ts
@@ -8,6 +8,7 @@ export interface BlogProps {
   description: string;
   backgroundImagePath: string | null;
   dDayStartDate: string;
+  memberIds: AggregateID[];
   deletedAt: Date | null;
 
   members?: HydratedUserEntityProps[];
@@ -20,6 +21,7 @@ export interface CreateBlogProps {
   description: string;
   backgroundImagePath: string | null;
   dDayStartDate: string;
+  memberIds: AggregateID[];
 }
 
 export interface HydratedBlogEntityProps extends BaseEntityProps {

--- a/src/features/blog/domain/blog.entity.ts
+++ b/src/features/blog/domain/blog.entity.ts
@@ -78,7 +78,7 @@ export class BlogEntity extends AggregateRoot<BlogProps> {
       : null;
   }
 
-  isMemberOfBlog(userId: AggregateID): boolean {
+  isMember(userId: AggregateID): boolean {
     return this.memberIds.includes(userId);
   }
 

--- a/src/features/blog/domain/blog.entity.ts
+++ b/src/features/blog/domain/blog.entity.ts
@@ -60,6 +60,10 @@ export class BlogEntity extends AggregateRoot<BlogProps> {
     return this.props.connectionId;
   }
 
+  get memberIds(): AggregateID[] {
+    return this.props.memberIds;
+  }
+
   get members(): HydratedUserEntityProps[] | null {
     return this.props.members || null;
   }
@@ -72,6 +76,10 @@ export class BlogEntity extends AggregateRoot<BlogProps> {
     return this.backgroundImagePath
       ? `${BlogEntity.BLOG_ATTACHMENT_URL}/${this.backgroundImagePath}`
       : null;
+  }
+
+  isMemberOfBlog(userId: AggregateID): boolean {
+    return this.memberIds.includes(userId);
   }
 
   editName(name: string) {

--- a/src/features/blog/dtos/response/blog.response-dto.ts
+++ b/src/features/blog/dtos/response/blog.response-dto.ts
@@ -13,6 +13,8 @@ export interface CreateBlogResponseDtoProps extends CreateBaseResponseDtoProps {
   description: string;
   dDayStartDate: string;
   backgroundImageUrl: string | null;
+  memberIds: AggregateID[];
+
   members?: HydratedUserResponseDto[];
 }
 
@@ -63,6 +65,14 @@ export class BlogResponseDto
   })
   readonly connectionId: AggregateID;
 
+  @ApiProperty({
+    format: 'int64',
+    description: '블로그에 속해 있는 유저 IDs',
+    type: 'string',
+    isArray: true,
+  })
+  readonly memberIds: AggregateID[];
+
   @ApiPropertyOptional({
     description: '블로그에 속해 있는 유저들 정보',
     type: [HydratedUserResponseDto],
@@ -76,6 +86,7 @@ export class BlogResponseDto
       name,
       createdBy,
       connectionId,
+      memberIds,
       members,
       description,
       dDayStartDate,
@@ -88,6 +99,7 @@ export class BlogResponseDto
     this.backgroundImageUrl = backgroundImageUrl;
     this.createdBy = createdBy;
     this.connectionId = connectionId;
+    this.memberIds = memberIds;
     this.members = members;
   }
 }

--- a/src/features/blog/mappers/blog.mapper.ts
+++ b/src/features/blog/mappers/blog.mapper.ts
@@ -17,6 +17,7 @@ export const blogSchema = baseSchema.extend({
   description: z.string().max(255),
   backgroundImagePath: z.nullable(z.string().max(255)),
   dDayStartDate: z.string().max(20),
+  memberIds: z.bigint().array(),
   deletedAt: z.preprocess(
     (val: any) => (val === null ? null : new Date(val)),
     z.nullable(z.date()),
@@ -40,6 +41,7 @@ export class BlogMapper
         description: blog.description,
         backgroundImagePath: blog.backgroundImagePath,
         dDayStartDate: blog.dDayStartDate,
+        memberIds: blog.memberIds,
         deletedAt: blog.deletedAt,
       },
       createdAt: blog.createdAt,
@@ -68,6 +70,7 @@ export class BlogMapper
       backgroundImageUrl: entity.backgroundImageUrl,
       connectionId: props.connectionId,
       createdBy: props.createdBy,
+      memberIds: props.memberIds,
       createdAt: props.createdAt,
       updatedAt: props.updatedAt,
     };

--- a/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
+++ b/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
@@ -63,6 +63,7 @@ export class FindOneBlogByUserIdQueryHandler
         : null,
       connectionId: blog.connectionId,
       createdBy: blog.createdBy,
+      memberIds: blog.memberIds,
       members: [
         {
           ...blog.connection.requesterUser,


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#142 

<!-- 내용 (필수) -->

### Description

UserConnection은 UserAggregateRoot의 Entity인데 현재 외부 AggregateRoot의 생성에 대한 제약을 갖고 있어, Entity인 것을 생각했을 때 책임을 과하게 가지고 있다고 생각이 듭니다.

그래서 UserConnection은 정말 이름과 역할 그대로 처음 유저의 연결에 대한 상태값만 관리하는 역할만 하도록 하려 합니다.

이후 블로그, 채팅룸 생성 시에는 중복된 값을 저장하더라도 이전처럼 외부의 Entity에 대한 참조를 꼭 필요로 하는 애매한 AggregateRoot가 아닌 책임을 좀 더 명확하게 가지고 가는 도메인으로 사용될 수 있을 것 같아서 이와 같이 수정했습니다.

추가적으로 FindPublicBlogPostsQueryHandler에선 해당 memberId를 사용하는 코드를 적용하지 않았는데 이유는, 그냥 2개 depth의 JOIN을 더 타는 게 애플리케이션 레벨에서 중첩 루프를 타서 매핑시켜주는 것보다 더 빠르다고 생각되어 수정하지 않았습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer
#138 PR이 merge되면 열겠습니다.