### PR TITLE
소켓 연결 시 토큰 가져올 프로퍼티 추가

### DIFF
--- a/src/features/chat-message/gateways/chat-message.gateway.ts
+++ b/src/features/chat-message/gateways/chat-message.gateway.ts
@@ -84,21 +84,22 @@ export class ChatMessageGateway
   server: Server;
 
   async handleConnection(socket: SocketWithUserDto) {
-    const authHeader = socket.handshake.headers.authorization;
+    const authProperty =
+      socket.handshake.auth?.token || socket.handshake.headers.authorization;
 
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    if (!authProperty || !authProperty.startsWith('Bearer ')) {
       this.logger.error(`Connection rejected: missing token ${socket.id}`);
       socket.disconnect();
       return;
     }
 
-    const token = authHeader.split(' ')[1];
+    const token = authProperty.split(' ')[1];
 
     try {
       const payload = await this.appJwtService.verifyToken(token);
 
       socket.user = { sub: payload.sub };
-      console.log(
+      this.logger.debug(
         `Connection accepted: ${socket.id}, userId: ${socket.user.sub}`,
       );
     } catch (error) {
@@ -110,7 +111,7 @@ export class ChatMessageGateway
   }
 
   async handleDisconnect(socket: SocketWithUserDto) {
-    console.log(`Disconnected: ${socket.id}`);
+    this.logger.debug(`Disconnected: ${socket.id}`);
   }
 
   @UsePipes(customValidationPipe)


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#153 

<!-- 내용 (필수) -->

### Description
소켓 연결 시 토큰 가져올 프로퍼티 추가
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer
기존에 `socket.handshake.headers.authorization` 에서 JWT 토큰을 가져와서 유저 검증을 진행했는데, 아래 레퍼런스 처럼 프론트에서 소켓 요청을 보낼 때 헤더 설정이 안된다고 합니다. 그래서 socket.io 3버전부터 auth 프로퍼티를 통해 토큰을 보내는 것을 지원하고 있어서 해당 방법으로 수정합니다.
(postman에선 auth 프로퍼티가 없어서 postman과 프론트 모두 검증 가능하도록 먼저 auth를 확인 후 header를 확인하도록 했습니다.)
<!-- 참고한 레퍼런스 링크 (선택) -->

### Reference Link
https://stackoverflow.com/questions/23406163/socket-io-client-how-to-set-request-header-when-making-connection
