### PR TITLE
블로그, 유저 관련 로직 1차 리팩터링

### DIFF
--- a/src/features/attachment/applications/event-handlers/create-attachment-when-blog-created.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/create-attachment-when-blog-created.domain-event-handler.ts
@@ -1,0 +1,45 @@
+import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
+import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
+import { BlogCreatedDomainEvent } from '@features/blog/domain/events/blog-created.domain-event';
+import { isNil } from '@libs/utils/util';
+import { Inject, Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class CreateAttachmentWhenBlogCreatedDomainEventHandler {
+  constructor(
+    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly attachmentRepository: AttachmentRepositoryPort,
+  ) {}
+
+  @OnEvent(BlogCreatedDomainEvent.name, {
+    suppressErrors: false,
+  })
+  async handle(event: BlogCreatedDomainEvent) {
+    const { backgroundImageFile, createdBy } = event;
+
+    if (isNil(backgroundImageFile)) {
+      return;
+    }
+
+    await this.attachmentRepository.create(
+      AttachmentEntity.create(
+        {
+          id: backgroundImageFile.fileId,
+          capacity: BigInt(backgroundImageFile.capacity),
+          mimeType: backgroundImageFile.mimeType,
+          uploadType: AttachmentUploadType.FILE,
+          userId: createdBy,
+          path: backgroundImageFile.backgroundImagePath.replace(
+            backgroundImageFile.fileId.toString(),
+            '',
+          ),
+          url: backgroundImageFile.attachmentUrl,
+        },
+        backgroundImageFile.buffer,
+      ),
+    );
+  }
+}

--- a/src/features/attachment/applications/event-handlers/update-attachment-when-blog-background-image-updated.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/update-attachment-when-blog-background-image-updated.domain-event-handler.ts
@@ -1,0 +1,71 @@
+import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
+import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
+import { BlogBackgroundImagePathUpdatedDomainEvent } from '@features/blog/domain/events/blog-background-image-updated.domain-event';
+import { isNil } from '@libs/utils/util';
+import { Inject, Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class UpdateAttachmentWhenBlogBackgroundImageUpdatedDomainEventHandler {
+  constructor(
+    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly attachmentRepository: AttachmentRepositoryPort,
+  ) {}
+
+  @OnEvent(BlogBackgroundImagePathUpdatedDomainEvent.name, {
+    suppressErrors: false,
+  })
+  async handle(event: BlogBackgroundImagePathUpdatedDomainEvent) {
+    const { backgroundImageFile, previousBackgroundImagePath, userId } = event;
+
+    if (isNil(backgroundImageFile)) {
+      if (backgroundImageFile === previousBackgroundImagePath) {
+        return;
+      }
+
+      await this.deletePreviousAttachment(previousBackgroundImagePath);
+
+      return;
+    }
+
+    if (!isNil(previousBackgroundImagePath)) {
+      await this.deletePreviousAttachment(previousBackgroundImagePath);
+    }
+
+    const newAttachment = AttachmentEntity.create(
+      {
+        id: backgroundImageFile.fileId,
+        userId,
+        path: backgroundImageFile.backgroundImagePath.replace(
+          backgroundImageFile.fileId.toString(),
+          '',
+        ),
+        mimeType: backgroundImageFile.mimeType,
+        capacity: BigInt(backgroundImageFile.capacity),
+        uploadType: AttachmentUploadType.FILE,
+        url: backgroundImageFile.attachmentUrl,
+      },
+      backgroundImageFile.buffer,
+    );
+
+    await this.attachmentRepository.create(newAttachment);
+  }
+
+  private async deletePreviousAttachment(
+    previousBackgroundImagePath: string,
+  ): Promise<void> {
+    const existingAttachment = await this.attachmentRepository.findOneByPath(
+      previousBackgroundImagePath,
+    );
+
+    if (isNil(existingAttachment)) {
+      return;
+    }
+
+    existingAttachment.delete();
+
+    await this.attachmentRepository.delete(existingAttachment);
+  }
+}

--- a/src/features/attachment/applications/event-handlers/update-attachment-when-user-profile-image-updated.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/update-attachment-when-user-profile-image-updated.domain-event-handler.ts
@@ -1,0 +1,71 @@
+import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
+import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
+import { UserProfileImagePathUpdatedDomainEvent } from '@features/user/domain/events/user-profile-image-path-updated.domain-event';
+import { isNil } from '@libs/utils/util';
+import { Inject, Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class UpdateAttachmentWhenUserProfileImageUpdatedDomainEventHandler {
+  constructor(
+    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly attachmentRepository: AttachmentRepositoryPort,
+  ) {}
+
+  @OnEvent(UserProfileImagePathUpdatedDomainEvent.name, {
+    suppressErrors: false,
+  })
+  async handle(event: UserProfileImagePathUpdatedDomainEvent) {
+    const { profileImageFile, previousProfileImagePath, aggregateId } = event;
+
+    if (isNil(profileImageFile)) {
+      if (profileImageFile === previousProfileImagePath) {
+        return;
+      }
+
+      await this.deletePreviousAttachment(previousProfileImagePath);
+
+      return;
+    }
+
+    if (!isNil(previousProfileImagePath)) {
+      await this.deletePreviousAttachment(previousProfileImagePath);
+    }
+
+    const newAttachment = AttachmentEntity.create(
+      {
+        id: profileImageFile.fileId,
+        userId: aggregateId,
+        path: profileImageFile.profileImagePath.replace(
+          profileImageFile.fileId.toString(),
+          '',
+        ),
+        mimeType: profileImageFile.mimeType,
+        capacity: BigInt(profileImageFile.capacity),
+        uploadType: AttachmentUploadType.FILE,
+        url: profileImageFile.attachmentUrl,
+      },
+      profileImageFile.buffer,
+    );
+
+    await this.attachmentRepository.create(newAttachment);
+  }
+
+  private async deletePreviousAttachment(
+    previousProfileImagePath: string,
+  ): Promise<void> {
+    const existingAttachment = await this.attachmentRepository.findOneByPath(
+      previousProfileImagePath,
+    );
+
+    if (isNil(existingAttachment)) {
+      return;
+    }
+
+    existingAttachment.delete();
+
+    await this.attachmentRepository.delete(existingAttachment);
+  }
+}

--- a/src/features/attachment/attachment.module.ts
+++ b/src/features/attachment/attachment.module.ts
@@ -9,6 +9,9 @@ import { CreateAttachmentsCommandHandler } from '@features/attachment/commands/c
 import { UploadAttachmentDomainEventHandler } from '@features/attachment/applications/event-handlers/upload-attachment.domain-event-handler';
 import { MoveAttachmentPathDomainEventHandler } from '@features/attachment/applications/event-handlers/move-attachment-path.domain-event-handler';
 import { DeleteAttachmentDomainEventHandler } from '@features/attachment/applications/event-handlers/delete-attachment.domain-event-handler';
+import { CreateAttachmentWhenBlogCreatedDomainEventHandler } from '@features/attachment/applications/event-handlers/create-attachment-when-blog-created.domain-event-handler';
+import { UpdateAttachmentWhenBlogBackgroundImageUpdatedDomainEventHandler } from '@features/attachment/applications/event-handlers/update-attachment-when-blog-background-image-updated.domain-event-handler';
+import { UpdateAttachmentWhenUserProfileImageUpdatedDomainEventHandler } from '@features/attachment/applications/event-handlers/update-attachment-when-user-profile-image-updated.domain-event-handler';
 
 const controllers = [AttachmentController];
 
@@ -27,6 +30,9 @@ const eventHandlers: Provider[] = [
   UploadAttachmentDomainEventHandler,
   MoveAttachmentPathDomainEventHandler,
   DeleteAttachmentDomainEventHandler,
+  CreateAttachmentWhenBlogCreatedDomainEventHandler,
+  UpdateAttachmentWhenBlogBackgroundImageUpdatedDomainEventHandler,
+  UpdateAttachmentWhenUserProfileImageUpdatedDomainEventHandler,
 ];
 
 @Module({

--- a/src/features/attachment/commands/create-attachments/create-attachments.command-handler.ts
+++ b/src/features/attachment/commands/create-attachments/create-attachments.command-handler.ts
@@ -5,8 +5,6 @@ import { CreateAttachmentsCommand } from '@features/attachment/commands/create-a
 import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
-import { Location } from '@features/attachment/domain/value-objects/location.value-object';
-import { getTsid } from 'tsid-ts';
 
 @CommandHandler(CreateAttachmentsCommand)
 export class CreateAttachmentsCommandHandler
@@ -22,21 +20,12 @@ export class CreateAttachmentsCommandHandler
     const { files, userId } = command;
 
     const attachments = files.map((file) => {
-      const id = getTsid().toBigInt();
-
-      const path = AttachmentEntity.ATTACHMENT_PATH_PREFIX + id;
-
       return AttachmentEntity.create(
         {
-          id,
           capacity: BigInt(file.capacity),
           mimeType: file.mimeType,
           uploadType: file.uploadType,
           userId,
-          location: new Location({
-            path,
-            url: `${AttachmentEntity.ATTACHMENT_URL}/${path}`,
-          }),
         },
         file.buffer,
       );

--- a/src/features/attachment/domain/attachment.entity-interface.ts
+++ b/src/features/attachment/domain/attachment.entity-interface.ts
@@ -11,10 +11,11 @@ export interface AttachmentProps {
 }
 
 export interface CreateAttachmentProps {
-  id: AggregateID;
   userId: AggregateID;
-  location: Location;
   mimeType: string;
   capacity: bigint;
   uploadType: AttachmentUploadTypeUnion;
+  path?: string;
+  id?: AggregateID;
+  url?: string;
 }

--- a/src/features/attachment/domain/attachment.entity.ts
+++ b/src/features/attachment/domain/attachment.entity.ts
@@ -14,6 +14,7 @@ import {
 } from '@features/attachment/domain/value-objects/location.value-object';
 import { AttachmentLocationChangedDomainEvent } from '@features/attachment/domain/events/attachment-location-changed.domain-event';
 import { AttachmentDeletedDomainEvent } from '@features/attachment/domain/events/attachment-deleted.domain-event';
+import { getTsid } from 'tsid-ts';
 
 export class AttachmentEntity extends AggregateRoot<AttachmentProps> {
   static readonly ATTACHMENT_MIME_TYPE: readonly string[] = [
@@ -33,10 +34,21 @@ export class AttachmentEntity extends AggregateRoot<AttachmentProps> {
     create: CreateAttachmentProps,
     buffer: Buffer,
   ): AttachmentEntity {
-    const { id, ...restProps } = create;
+    const id = create.id ?? getTsid().toBigInt();
+    const path = create.path
+      ? create.path + id
+      : AttachmentEntity.ATTACHMENT_PATH_PREFIX + id;
+    const url = `${create.url ?? AttachmentEntity.ATTACHMENT_URL}/${path}`;
 
     const props: AttachmentProps = {
-      ...restProps,
+      userId: create.userId,
+      mimeType: create.mimeType,
+      capacity: create.capacity,
+      uploadType: create.uploadType,
+      location: new Location({
+        path,
+        url,
+      }),
     };
 
     const attachment = new AttachmentEntity({ id, props });

--- a/src/features/attachment/repositories/attachment.repository-port.ts
+++ b/src/features/attachment/repositories/attachment.repository-port.ts
@@ -20,4 +20,6 @@ export interface AttachmentRepositoryPort
    * @description DomainEvent를 발생시키지 않음.
    */
   deleteById(id: AggregateID): Promise<void>;
+
+  findOneByPath(path: string): Promise<AttachmentEntity | undefined>;
 }

--- a/src/features/attachment/repositories/attachment.repository.ts
+++ b/src/features/attachment/repositories/attachment.repository.ts
@@ -121,6 +121,14 @@ export class AttachmentRepository implements AttachmentRepositoryPort {
     return records.map((record) => this.mapper.toEntity(record));
   }
 
+  async findOneByPath(path: string): Promise<AttachmentEntity | undefined> {
+    const record = await this.txHost.tx.attachment.findUnique({
+      where: { path },
+    });
+
+    return record ? this.mapper.toEntity(record) : undefined;
+  }
+
   async bulkDelete(entities: AttachmentEntity[]): Promise<void> {
     if (!entities.length) {
       return;

--- a/src/features/blog/blog.module.ts
+++ b/src/features/blog/blog.module.ts
@@ -1,4 +1,3 @@
-import { AttachmentModule } from '@features/attachment/attachment.module';
 import { CreateBlogCommandHandler } from '@features/blog/commands/create-blog/create-blog.command-handler';
 import { PatchUpdateBlogCommandHandler } from '@features/blog/commands/patch-update-blog/patch-update-blog.command-handler';
 import { BlogController } from '@features/blog/controllers/blog.controller';
@@ -9,7 +8,6 @@ import { FindOneBlogByUserIdQueryHandler } from '@features/blog/queries/find-one
 import { BlogRepository } from '@features/blog/repositories/blog.repository';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { UserModule } from '@features/user/user.module';
-import { S3Module } from '@libs/s3/s3.module';
 import { Module, Provider } from '@nestjs/common';
 import { NestjsFormDataModule } from 'nestjs-form-data';
 
@@ -35,7 +33,7 @@ const repositories: Provider[] = [
 const domainServices: Provider[] = [BlogDomainService];
 
 @Module({
-  imports: [UserModule, NestjsFormDataModule, AttachmentModule, S3Module],
+  imports: [UserModule, NestjsFormDataModule],
   controllers: [...controllers],
   providers: [
     ...mappers,

--- a/src/features/blog/blog.module.ts
+++ b/src/features/blog/blog.module.ts
@@ -3,6 +3,7 @@ import { CreateBlogCommandHandler } from '@features/blog/commands/create-blog/cr
 import { PatchUpdateBlogCommandHandler } from '@features/blog/commands/patch-update-blog/patch-update-blog.command-handler';
 import { BlogController } from '@features/blog/controllers/blog.controller';
 import { BlogUserConnectionDisconnectDomainEventHandler } from '@features/blog/application/event-handlers/blog-user-connection-disconnect.domain-event-handler';
+import { BlogDomainService } from '@features/blog/domain/domain-services/blog.domain-service';
 import { BlogMapper } from '@features/blog/mappers/blog.mapper';
 import { FindOneBlogByUserIdQueryHandler } from '@features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler';
 import { BlogRepository } from '@features/blog/repositories/blog.repository';
@@ -31,6 +32,8 @@ const repositories: Provider[] = [
   { provide: BLOG_REPOSITORY_DI_TOKEN, useClass: BlogRepository },
 ];
 
+const domainServices: Provider[] = [BlogDomainService];
+
 @Module({
   imports: [UserModule, NestjsFormDataModule, AttachmentModule, S3Module],
   controllers: [...controllers],
@@ -40,6 +43,7 @@ const repositories: Provider[] = [
     ...repositories,
     ...queryHandlers,
     ...eventHandlers,
+    ...domainServices,
   ],
   exports: [...repositories, ...mappers],
 })

--- a/src/features/blog/commands/create-blog/create-blog.command-handler.ts
+++ b/src/features/blog/commands/create-blog/create-blog.command-handler.ts
@@ -10,6 +10,7 @@ import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/except
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
 import { BlogDomainService } from '@features/blog/domain/domain-services/blog.domain-service';
+import { Transactional } from '@nestjs-cls/transactional';
 
 @CommandHandler(CreateBlogCommand)
 export class CreateBlogCommandHandler
@@ -24,6 +25,7 @@ export class CreateBlogCommandHandler
     private readonly blogDomainService: BlogDomainService,
   ) {}
 
+  @Transactional()
   async execute(command: CreateBlogCommand): Promise<AggregateID> {
     const { userId, name, description, dDayStartDate, backgroundImageFile } =
       command;

--- a/src/features/blog/commands/create-blog/create-blog.command-handler.ts
+++ b/src/features/blog/commands/create-blog/create-blog.command-handler.ts
@@ -3,23 +3,13 @@ import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { AggregateID } from '@libs/ddd/entity.base';
-import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions/http-conflict.exception';
-import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
-import { BLOG_ERROR_CODE } from '@libs/exceptions/types/errors/blog/blog-error-code.constant';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
-import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { CreateBlogCommand } from '@features/blog/commands/create-blog/create-blog.command';
-import { BlogEntity } from '@features/blog/domain/blog.entity';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
-import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
-import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
-import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
-import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
-import { Location } from '@features/attachment/domain/value-objects/location.value-object';
-import { getTsid } from 'tsid-ts';
+import { BlogDomainService } from '@features/blog/domain/domain-services/blog.domain-service';
 
 @CommandHandler(CreateBlogCommand)
 export class CreateBlogCommandHandler
@@ -30,8 +20,8 @@ export class CreateBlogCommandHandler
     private readonly userRepository: UserRepositoryPort,
     @Inject(BLOG_REPOSITORY_DI_TOKEN)
     private readonly blogRepository: BlogRepositoryPort,
-    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
-    private readonly attachmentRepository: AttachmentRepositoryPort,
+
+    private readonly blogDomainService: BlogDomainService,
   ) {}
 
   async execute(command: CreateBlogCommand): Promise<AggregateID> {
@@ -49,64 +39,11 @@ export class CreateBlogCommandHandler
       });
     }
 
-    const acceptedConnection = user.acceptedConnection;
-
-    if (isNil(acceptedConnection)) {
-      throw new HttpForbiddenException({
-        code: USER_CONNECTION_ERROR_CODE.YOU_DO_NOT_HAVE_AN_ACCEPTED_CONNECTION,
-      });
-    }
-
-    const existingBlog = await this.blogRepository.findOneByConnectionId(
-      acceptedConnection.id,
-    );
-
-    if (!isNil(existingBlog)) {
-      throw new HttpConflictException({
-        code: BLOG_ERROR_CODE.YOU_ALREADY_HAVE_A_BLOG,
-      });
-    }
-
-    let backgroundImagePath: string | null = null;
-
-    if (!isNil(backgroundImageFile)) {
-      const { mimeType, capacity, buffer } = backgroundImageFile;
-
-      const id = getTsid().toBigInt();
-      const path = BlogEntity.BLOG_ATTACHMENT_PATH_PREFIX + id;
-      const url = `${BlogEntity.BLOG_ATTACHMENT_URL}/${path}`;
-
-      const attachment = AttachmentEntity.create(
-        {
-          id,
-          userId,
-          capacity: BigInt(capacity),
-          mimeType,
-          uploadType: AttachmentUploadType.FILE,
-          location: new Location({
-            path,
-            url,
-          }),
-        },
-        buffer,
-      );
-
-      await this.attachmentRepository.create(attachment);
-
-      backgroundImagePath = path;
-    }
-
-    const blog = BlogEntity.create({
-      createdBy: userId,
-      connectionId: acceptedConnection.id,
+    const blog = await this.blogDomainService.create(user, {
       name,
       description,
       dDayStartDate,
-      backgroundImagePath,
-      memberIds: [
-        acceptedConnection.requesterId,
-        acceptedConnection.requestedId,
-      ],
+      backgroundImageFile,
     });
 
     await this.blogRepository.create(blog);

--- a/src/features/blog/commands/create-blog/create-blog.command.ts
+++ b/src/features/blog/commands/create-blog/create-blog.command.ts
@@ -1,17 +1,14 @@
 import { ICommand } from '@nestjs/cqrs';
 import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
+import { FileProps } from '@libs/types/type';
 
 export class CreateBlogCommand extends Command implements ICommand {
   readonly userId: AggregateID;
   readonly name: string;
   readonly description: string;
   readonly dDayStartDate: string;
-  readonly backgroundImageFile: {
-    mimeType: string;
-    capacity: number;
-    buffer: Buffer;
-  } | null;
+  readonly backgroundImageFile: FileProps | null;
 
   constructor(props: CommandProps<CreateBlogCommand>) {
     super(props);

--- a/src/features/blog/domain/blog.entity-interface.ts
+++ b/src/features/blog/domain/blog.entity-interface.ts
@@ -1,5 +1,6 @@
 import { HydratedUserEntityProps } from '@features/user/domain/user.entity-interface';
 import { AggregateID, BaseEntityProps } from '@libs/ddd/entity.base';
+import { FileProps } from '@libs/types/type';
 
 export interface BlogProps {
   createdBy: AggregateID;
@@ -19,7 +20,7 @@ export interface CreateBlogProps {
   connectionId: AggregateID;
   name: string;
   description: string;
-  backgroundImagePath: string | null;
+  backgroundImageFile: FileProps | null;
   dDayStartDate: string;
   memberIds: AggregateID[];
 }

--- a/src/features/blog/domain/blog.errors.ts
+++ b/src/features/blog/domain/blog.errors.ts
@@ -1,0 +1,10 @@
+import { DomainException } from '@libs/ddd/domain-exception.base';
+import { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
+
+export class CannotCreateBlogWithoutAcceptedConnectionError extends DomainException {
+  readonly code = ERROR_CODE.YOU_DO_NOT_HAVE_AN_ACCEPTED_CONNECTION;
+}
+
+export class BlogAlreadyExistsError extends DomainException {
+  readonly code = ERROR_CODE.YOU_ALREADY_HAVE_A_BLOG;
+}

--- a/src/features/blog/domain/domain-services/blog.domain-service.ts
+++ b/src/features/blog/domain/domain-services/blog.domain-service.ts
@@ -1,0 +1,62 @@
+import { BlogEntity } from '@features/blog/domain/blog.entity';
+import { CreateBlogProps } from '@features/blog/domain/blog.entity-interface';
+import {
+  BlogAlreadyExistsError,
+  CannotCreateBlogWithoutAcceptedConnectionError,
+} from '@features/blog/domain/blog.errors';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
+import { UserEntity } from '@features/user/domain/user.entity';
+import { isNil } from '@libs/utils/util';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class BlogDomainService {
+  constructor(
+    /**
+     * DomainService에 Repository를 주입하는 것은 지양해야 하지만
+     * acceptedConnection 및 블로그에 대한 중복 생성 여부 체크는 비즈니스 로직이라고 생각되어 DomainService에서 이루어지는 게 맞다고 생각함.
+     * 근데 DomainService에서 이 두 가지 로직을 모두 처리하기 위해선 Repository를 주입이 불가피함.
+     */
+    @Inject(BLOG_REPOSITORY_DI_TOKEN)
+    private readonly blogRepository: BlogRepositoryPort,
+  ) {}
+
+  async create(
+    user: UserEntity,
+    createBlogProps: Omit<
+      CreateBlogProps,
+      'createdBy' | 'connectionId' | 'memberIds'
+    >,
+  ) {
+    const { name, description, dDayStartDate, backgroundImageFile } =
+      createBlogProps;
+
+    const acceptedConnection = user.acceptedConnection;
+
+    if (isNil(acceptedConnection)) {
+      throw new CannotCreateBlogWithoutAcceptedConnectionError();
+    }
+
+    const existingBlog = await this.blogRepository.findOneByConnectionId(
+      acceptedConnection.id,
+    );
+
+    if (!isNil(existingBlog)) {
+      throw new BlogAlreadyExistsError();
+    }
+
+    return BlogEntity.create({
+      createdBy: user.id,
+      connectionId: acceptedConnection.id,
+      name,
+      description,
+      dDayStartDate,
+      backgroundImageFile,
+      memberIds: [
+        acceptedConnection.requestedId,
+        acceptedConnection.requesterId,
+      ],
+    });
+  }
+}

--- a/src/features/blog/domain/events/blog-background-image-updated.domain-event.ts
+++ b/src/features/blog/domain/events/blog-background-image-updated.domain-event.ts
@@ -1,0 +1,27 @@
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { FileProps } from '@libs/types/type';
+
+export class BlogBackgroundImagePathUpdatedDomainEvent extends DomainEvent {
+  readonly backgroundImageFile:
+    | (FileProps & {
+        fileId: AggregateID;
+        backgroundImagePath: string;
+        attachmentUrl: string;
+      })
+    | null;
+  readonly previousBackgroundImagePath: string | null;
+  readonly userId: AggregateID;
+
+  constructor(
+    props: DomainEventProps<BlogBackgroundImagePathUpdatedDomainEvent>,
+  ) {
+    super(props);
+
+    const { backgroundImageFile, previousBackgroundImagePath, userId } = props;
+
+    this.backgroundImageFile = backgroundImageFile;
+    this.previousBackgroundImagePath = previousBackgroundImagePath;
+    this.userId = userId;
+  }
+}

--- a/src/features/blog/domain/events/blog-created.domain-event.ts
+++ b/src/features/blog/domain/events/blog-created.domain-event.ts
@@ -1,0 +1,23 @@
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { FileProps } from '@libs/types/type';
+
+export class BlogCreatedDomainEvent extends DomainEvent {
+  readonly backgroundImageFile:
+    | (FileProps & {
+        fileId: AggregateID;
+        backgroundImagePath: string;
+        attachmentUrl: string;
+      })
+    | null;
+  readonly createdBy: AggregateID;
+
+  constructor(props: DomainEventProps<BlogCreatedDomainEvent>) {
+    super(props);
+
+    const { backgroundImageFile, createdBy } = props;
+
+    this.backgroundImageFile = backgroundImageFile;
+    this.createdBy = createdBy;
+  }
+}

--- a/src/features/blog/repositories/blog.repository.ts
+++ b/src/features/blog/repositories/blog.repository.ts
@@ -71,6 +71,8 @@ export class BlogRepository implements BlogRepositoryPort {
       data: record,
     });
 
+    await entity.publishEvents(this.eventEmitter);
+
     return this.mapper.toEntity(updatedRecord);
   }
 
@@ -80,6 +82,7 @@ export class BlogRepository implements BlogRepositoryPort {
     const record = await this.txHost.tx.blog.findFirst({
       where: {
         connectionId,
+        deletedAt: null,
       },
     });
 

--- a/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
+++ b/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
@@ -1,21 +1,13 @@
-import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
-import { Location } from '@features/attachment/domain/value-objects/location.value-object';
-import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
-import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
-import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
 import { PatchUpdateUserCommand } from '@features/user/commands/patch-update-user/patch-update-user.command';
 import { UserEntity } from '@features/user/domain/user.entity';
 import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
-import { S3ServicePort } from '@libs/s3/services/s3.service-port';
-import { S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { getTsid } from 'tsid-ts';
 
 @CommandHandler(PatchUpdateUserCommand)
 export class PatchUpdateUserCommandHandler
@@ -24,10 +16,6 @@ export class PatchUpdateUserCommandHandler
   constructor(
     @Inject(USER_REPOSITORY_DI_TOKEN)
     private readonly userRepository: UserRepositoryPort,
-    @Inject(S3_SERVICE_DI_TOKEN)
-    private readonly s3Service: S3ServicePort,
-    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
-    private readonly attachmentRepository: AttachmentRepositoryPort,
   ) {}
 
   @Transactional()
@@ -50,65 +38,22 @@ export class PatchUpdateUserCommandHandler
       user.editMbti(mbti);
     }
 
-    if (!isNil(profileImageFile)) {
-      await this.deleteProfileImage(user);
+    if (profileImageFile !== undefined) {
+      this.deleteProfileImage(user);
 
-      /**
-       * @todo 현재 파일에 관련한 중복 로직이 많음.
-       * 또한 현재 Attachment를 생성하는 방식은 CreateAttachmentHandler
-       * 혹은 각 도메인의 핸들러에서 외부의 AggregateRoot인 Attachment를 생성해주는데
-       * Attachment 관련한 작업의 중복 제거를 위함 및
-       * Attachment의 LifeCycle에 관한 책임을 갖고 있는 중간 다리 역할인 AttachmentService가 필요해 보임.
-       * 추후에 수정 필요.
-       */
-      const { mimeType, capacity, buffer } = profileImageFile;
-
-      const id = getTsid().toBigInt();
-      const path = UserEntity.USER_ATTACHMENT_PATH_PREFIX + id;
-      const url = `${UserEntity.USER_ATTACHMENT_URL}/${path}`;
-
-      const attachment = AttachmentEntity.create(
-        {
-          id,
-          userId,
-          capacity: BigInt(capacity),
-          mimeType,
-          uploadType: AttachmentUploadType.FILE,
-          location: new Location({
-            path,
-            url,
-          }),
-        },
-        buffer,
-      );
-
-      await this.attachmentRepository.create(attachment);
-
-      user.editProfileImagePath(path);
-    } else if (profileImageFile === null) {
-      await this.deleteProfileImage(user);
+      if (profileImageFile) {
+        user.updateProfileImage(profileImageFile);
+      }
     }
 
     await this.userRepository.update(user);
   }
 
-  private async deleteProfileImage(user: UserEntity): Promise<void> {
+  private deleteProfileImage(user: UserEntity): void {
     const profileImageUrl = user.profileImageUrl;
 
     if (!isNil(profileImageUrl)) {
-      const existingAttachment = (
-        await this.attachmentRepository.findByUrls([profileImageUrl])
-      )[0];
-
-      if (isNil(existingAttachment)) {
-        return;
-      }
-
-      existingAttachment.delete();
-
-      await this.attachmentRepository.delete(existingAttachment);
-
-      user.editProfileImagePath(null);
+      user.updateProfileImage(null);
     }
   }
 }

--- a/src/features/user/domain/events/user-profile-image-path-updated.domain-event.ts
+++ b/src/features/user/domain/events/user-profile-image-path-updated.domain-event.ts
@@ -1,0 +1,23 @@
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { FileProps } from '@libs/types/type';
+
+export class UserProfileImagePathUpdatedDomainEvent extends DomainEvent {
+  readonly profileImageFile:
+    | (FileProps & {
+        fileId: AggregateID;
+        profileImagePath: string;
+        attachmentUrl: string;
+      })
+    | null;
+  readonly previousProfileImagePath: string | null;
+
+  constructor(props: DomainEventProps<UserProfileImagePathUpdatedDomainEvent>) {
+    super(props);
+
+    const { profileImageFile, previousProfileImagePath } = props;
+
+    this.profileImageFile = profileImageFile;
+    this.previousProfileImagePath = previousProfileImagePath;
+  }
+}

--- a/src/features/user/repositories/user.repository.ts
+++ b/src/features/user/repositories/user.repository.ts
@@ -83,6 +83,7 @@ export class UserRepository implements UserRepositoryPort {
       data: record,
     });
 
+    await entity.publishEvents(this.eventEmitter);
     return this.mapper.toEntity(updatedRecord);
   }
 

--- a/src/features/user/user.module.ts
+++ b/src/features/user/user.module.ts
@@ -24,8 +24,6 @@ import { FindOneUserQueryHandler } from '@features/user/queries/find-one-user/fi
 import { DisconnectUserConnectionCommandHandler } from '@features/user/user-connection/commands/disconnect-user-connection/disconnect-user-connection.command-handler';
 import { NestjsFormDataModule } from 'nestjs-form-data';
 import { PatchUpdateUserCommandHandler } from '@features/user/commands/patch-update-user/patch-update-user.command-handler';
-import { S3Module } from '@libs/s3/s3.module';
-import { AttachmentModule } from '@features/attachment/attachment.module';
 
 const controllers = [UserController, UserConnectionController];
 
@@ -66,7 +64,7 @@ const mappers: Provider[] = [
 ];
 
 @Module({
-  imports: [EmailModule, NestjsFormDataModule, S3Module, AttachmentModule],
+  imports: [EmailModule, NestjsFormDataModule],
   controllers: [...controllers],
   providers: [
     ...mappers,

--- a/src/libs/ddd/domain-exception.base.ts
+++ b/src/libs/ddd/domain-exception.base.ts
@@ -1,0 +1,6 @@
+import { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
+import { ValueOf } from '@libs/types/type';
+
+export abstract class DomainException {
+  abstract readonly code: ValueOf<typeof ERROR_CODE>;
+}

--- a/src/libs/types/type.ts
+++ b/src/libs/types/type.ts
@@ -37,3 +37,9 @@ export type SingleProperty<T> = {
 
 export type HandlerReturnType<T extends IQueryHandler | ICommandHandler> =
   ReturnType<T['execute']>;
+
+export type FileProps = {
+  mimeType: string;
+  capacity: number;
+  buffer: Buffer;
+};


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#170 

<!-- 내용 (필수) -->

### Description

작업 내용
- Request,response logger 에러 로직 수정
- 블로그 생성 시 BlogDomainService를 통해 비즈니스 로직 의사 결정
  - DomainException을 throw하도록 수정
  - DomainService 내에 Repository를 주입하는 것은 지양해야 하나 '블로그를 2개 이상 생성하지 못한다'는 비즈니스 로직 검증을 위해 예외적으로 repository 주입
- Blog, User Attachment 관련 로직 EventHandler에서 처리되도록 수정

추후 작업할 내용
- BlogPost의 Attachment 관련 로직 EventHandler로 이관
- 도메인 레이어 내의 모든 Exception은 DomainException을 throw 하도록 수정

### To Reviewer

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

앞으로 새로 작업할 때 도메인 레이어 내에서 던져지는 Exception을 따로 만들어 핸들링 해주시기 바랍니다

<!-- 참고한 레퍼런스 링크 (선택) -->

### Reference Link

[[DDD] Domain Service vs Application Service](https://www.borntodare.me/ef699637-514c-469e-9a2f-32718b911b72)
[Domain model에서 repository를 직접 사용해도 될까? - 도메인 모델의 영속성 무지](https://littlemobs.com/blog/using-repository-in-domain-model/)