### PR TITLE
유저 회원탈퇴 api 추가

### DIFF
--- a/src/configs/app.route.ts
+++ b/src/configs/app.route.ts
@@ -25,6 +25,7 @@ export const routesV1 = {
     sendVerificationEmail: `${userRoot}/me/user-verify-tokens/email`,
     sendPasswordChangeVerificationEmail: `${userRoot}/:email/user-verify-tokens/password-change`,
     patchUpdate: `${userRoot}/me`,
+    delete: `${userRoot}/me`,
   },
 
   userConnection: {

--- a/src/features/user/commands/delete-user/delete-user.command-handler.ts
+++ b/src/features/user/commands/delete-user/delete-user.command-handler.ts
@@ -1,0 +1,51 @@
+import { DeleteUserCommand } from '@features/user/commands/delete-user/delete-user.command';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
+import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
+import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
+import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
+import { isNil } from '@libs/utils/util';
+import { Transactional } from '@nestjs-cls/transactional';
+import { Inject } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+@CommandHandler(DeleteUserCommand)
+export class DeleteUserCommandHandler
+  implements ICommandHandler<DeleteUserCommand, void>
+{
+  constructor(
+    @Inject(USER_REPOSITORY_DI_TOKEN)
+    private readonly userRepository: UserRepositoryPort,
+  ) {}
+
+  @Transactional()
+  async execute(command: DeleteUserCommand): Promise<void> {
+    const { userId } = command;
+
+    const user = await this.userRepository.findOneById(userId, {
+      requestedConnections: true,
+      requesterConnections: true,
+    });
+
+    if (isNil(user)) {
+      throw new HttpNotFoundException({
+        code: COMMON_ERROR_CODE.RESOURCE_NOT_FOUND,
+      });
+    }
+
+    const userConnection = user.acceptedConnection;
+
+    user.delete();
+
+    if (userConnection) {
+      user.processConnectionRequest(
+        UserConnectionStatus.DISCONNECTED,
+        userConnection.id,
+      );
+
+      await this.userRepository.updateUserConnection(user, userConnection);
+    }
+
+    await this.userRepository.delete(user);
+  }
+}

--- a/src/features/user/commands/delete-user/delete-user.command.ts
+++ b/src/features/user/commands/delete-user/delete-user.command.ts
@@ -1,0 +1,13 @@
+import { Command, CommandProps } from '@libs/ddd/command.base';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
+
+export class DeleteUserCommand extends Command implements ICommand {
+  readonly userId: AggregateID;
+
+  constructor(props: CommandProps<DeleteUserCommand>) {
+    super(props);
+
+    this.userId = props.userId;
+  }
+}

--- a/src/features/user/controllers/user.controller.ts
+++ b/src/features/user/controllers/user.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -41,6 +42,7 @@ import { FormDataRequest } from 'nestjs-form-data';
 import { PatchUpdateUserRequestBodyDto } from '@features/user/dtos/request/patch-update-user.request-body-dto';
 import { PatchUpdateUserCommand } from '@features/user/commands/patch-update-user/patch-update-user.command';
 import { NotEmptyObjectPipe } from '@libs/api/pipes/not-empty-object.pipe';
+import { DeleteUserCommand } from '@features/user/commands/delete-user/delete-user.command';
 
 @ApiTags('User')
 @ApiInternalServerErrorBuilder()
@@ -187,5 +189,18 @@ export class UserController {
     });
 
     await this.commandBus.execute(command);
+  }
+
+  @ApiUser.Delete({
+    summary: '유저 회원탈퇴(삭제) API',
+  })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Delete(routesV1.user.delete)
+  async delete(@User('sub') userId: AggregateID): Promise<void> {
+    const command = new DeleteUserCommand({
+      userId,
+    });
+
+    await this.commandBus.execute<DeleteUserCommand, void>(command);
   }
 }

--- a/src/features/user/controllers/user.swagger.ts
+++ b/src/features/user/controllers/user.swagger.ts
@@ -367,4 +367,30 @@ export const ApiUser: ApiOperator<keyof Omit<UserController, 'verifyEmail'>> = {
       ]),
     );
   },
+
+  Delete: (
+    apiOperationOptions: ApiOperationOptionsWithSummary,
+  ): MethodDecorator => {
+    return applyDecorators(
+      ApiOperation({
+        ...apiOperationOptions,
+      }),
+      ApiBearerAuth('access-token'),
+      ApiNoContentResponse({
+        description: '정상적으로 유저 삭제됨.',
+      }),
+      HttpUnauthorizedException.swaggerBuilder(HttpStatus.UNAUTHORIZED, [
+        {
+          code: COMMON_ERROR_CODE.INVALID_TOKEN,
+          description: '유효하지 않은 토큰으로 인해 발생하는 에러',
+        },
+      ]),
+      HttpNotFoundException.swaggerBuilder(HttpStatus.NOT_FOUND, [
+        {
+          code: COMMON_ERROR_CODE.RESOURCE_NOT_FOUND,
+          description: '유저를 찾을 수 없습니다.',
+        },
+      ]),
+    );
+  },
 };

--- a/src/features/user/domain/events/user-deleted.domain-event.ts
+++ b/src/features/user/domain/events/user-deleted.domain-event.ts
@@ -1,0 +1,7 @@
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
+
+export class UserDeletedDomainEvent extends DomainEvent {
+  constructor(props: DomainEventProps<UserDeletedDomainEvent>) {
+    super(props);
+  }
+}

--- a/src/features/user/domain/user.entity.ts
+++ b/src/features/user/domain/user.entity.ts
@@ -30,6 +30,7 @@ import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { UserMbtiUnion } from '@features/user/types/user.type';
 import { UserConnectionDisconnectedDomainEvent } from '@features/user/domain/events/user-connection-disconnected.domain-event';
+import { UserDeletedDomainEvent } from '@features/user/domain/events/user-deleted.domain-event';
 
 export class UserEntity extends AggregateRoot<UserProps> {
   static readonly USER_ATTACHMENT_URL = process.env.USER_ATTACHMENT_URL;
@@ -340,6 +341,10 @@ export class UserEntity extends AggregateRoot<UserProps> {
         (connection) => connection.id === connectionId,
       ) || null
     );
+  }
+
+  delete(): void {
+    this.addEvent(new UserDeletedDomainEvent({ aggregateId: this.id }));
   }
 
   private get requestedConnections() {

--- a/src/features/user/repositories/user.repository.ts
+++ b/src/features/user/repositories/user.repository.ts
@@ -54,8 +54,9 @@ export class UserRepository implements UserRepositoryPort {
   async delete(entity: UserEntity): Promise<AggregateID> {
     entity.validate();
 
-    const result = await this.txHost.tx.user.delete({
+    const result = await this.txHost.tx.user.update({
       where: { id: entity.id },
+      data: { deletedAt: new Date() },
     });
 
     await entity.publishEvents(this.eventEmitter);

--- a/src/features/user/user.module.ts
+++ b/src/features/user/user.module.ts
@@ -26,6 +26,7 @@ import { NestjsFormDataModule } from 'nestjs-form-data';
 import { PatchUpdateUserCommandHandler } from '@features/user/commands/patch-update-user/patch-update-user.command-handler';
 import { S3Module } from '@libs/s3/s3.module';
 import { AttachmentModule } from '@features/attachment/attachment.module';
+import { DeleteUserCommandHandler } from '@features/user/commands/delete-user/delete-user.command-handler';
 
 const controllers = [UserController, UserConnectionController];
 
@@ -39,6 +40,7 @@ const commandHandlers: Provider[] = [
   UpdateUserConnectionCommandHandler,
   DisconnectUserConnectionCommandHandler,
   PatchUpdateUserCommandHandler,
+  DeleteUserCommandHandler,
 ];
 
 const queryHandlers: Provider[] = [


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#172 

<!-- 내용 (필수) -->

### Description
유저 회원탈퇴 API를 추가했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer
`DeleteUserCommandHandler` 내에서 유저 삭제와 유저 커넥션 해제까지 같이 하고 있습니다.
유저 삭제 후 userDeletedEvent를 발행하고, 해당 이벤트를 리스닝하여 유저 커넥션 해제를 하도록 만들까 했는데
그러면 유저가 삭제된 이후에 유저 커넥션을 삭제하는거라 EventHandler에서 user가 존재하는지 확인하기 위해 `findOneById()`메서드를 사용하게 되면 undefined가 리턴되는 문제가 발생하더라구요.

deletedAt이 null인 유저를 찾는 메서드를 추가할까 했는데 '삭제했는데 조회한다?' 라는게 의미적으로 별로인거 같아서 `DeleteUserCommandHandler` 내에서 유저 삭제와 유저 커넥션 해제까지 하도록 했습니다.

그리고 `UserDeletedDomainEvent`는 다른곳에서도 사용할 수도 있을거 같아서 추가해놨습니다.


### API

| Method | Path      | 설명           | 작업(추가, 수정, 삭제) |
| ------ | --------- | -------------- | ---------------------- |
| DELETE    | /api/v1/users/me | 유저 회원탈퇴 | 추가                   |
