### PR TITLE
BlogPost 도메인 관련 로직 리팩터링

### DIFF
--- a/src/features/attachment/applications/event-handlers/create-thumbnail-attachment-when-blog-post-created.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/create-thumbnail-attachment-when-blog-post-created.domain-event-handler.ts
@@ -1,0 +1,46 @@
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
+import { BlogPostCreatedDomainEvent } from '@features/blog-post/domain/events/blog-post-created.domain-event';
+import { isNil } from '@libs/utils/util';
+import { Inject, Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class CreateThumbnailAttachmentWhenBlogPostCreatedDomainEventHandler {
+  constructor(
+    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly attachmentRepository: AttachmentRepositoryPort,
+  ) {}
+
+  @OnEvent(BlogPostCreatedDomainEvent.name, {
+    async: true,
+  })
+  async handle(event: BlogPostCreatedDomainEvent) {
+    const { thumbnailImageUrl, attachmentUrl, attachmentPath } = event;
+
+    if (isNil(thumbnailImageUrl)) {
+      return;
+    }
+
+    const attachmentId = BigInt(
+      thumbnailImageUrl.replace(attachmentUrl, '').replace(attachmentPath, ''),
+    );
+
+    const existingAttachment =
+      await this.attachmentRepository.findOneById(attachmentId);
+
+    if (isNil(existingAttachment)) {
+      return;
+    }
+
+    const movedPath = attachmentPath + existingAttachment.id;
+    const movedUrl = `${attachmentUrl}/${movedPath}`;
+
+    existingAttachment.changeLocation({
+      path: movedPath,
+      url: movedUrl,
+    });
+
+    await this.attachmentRepository.update(existingAttachment);
+  }
+}

--- a/src/features/attachment/applications/event-handlers/delete-attachments-when-blog-post-updated.domain-event-hanlder.ts
+++ b/src/features/attachment/applications/event-handlers/delete-attachments-when-blog-post-updated.domain-event-hanlder.ts
@@ -1,0 +1,62 @@
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
+import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
+import { BlogPostUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-updated.domain-event';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { isNil } from '@libs/utils/util';
+import { Propagation, Transactional } from '@nestjs-cls/transactional';
+import { Inject, Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class DeleteAttachmentsWhenBlogPostUpdatedDomainEventHandler {
+  constructor(
+    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly attachmentRepository: AttachmentRepositoryPort,
+  ) {}
+
+  @OnEvent(BlogPostUpdatedDomainEvent.name, {
+    async: true,
+  })
+  @Transactional(Propagation.RequiresNew)
+  async handle(event: BlogPostUpdatedDomainEvent) {
+    const { contents } = event.updatedProps;
+
+    if (isNil(contents)) {
+      return;
+    }
+
+    const { newContents, blogPostAttachments } = contents;
+
+    if (!isNil(blogPostAttachments)) {
+      const attachmentIds = blogPostAttachments.map(
+        (blogPostAttachment) => blogPostAttachment.attachmentId,
+      );
+
+      const existingAttachments =
+        await this.attachmentRepository.findByIdsAndUploadType(
+          attachmentIds,
+          AttachmentUploadType.IMAGE,
+        );
+
+      const jsonContents = JSON.stringify(newContents);
+
+      const deletedAttachmentIdsSet = new Set<AggregateID>();
+
+      const deletedAttachments = existingAttachments.filter(
+        (existingAttachment) => {
+          const isDeleted = !jsonContents.includes(existingAttachment.url);
+
+          if (isDeleted) {
+            existingAttachment.delete();
+            deletedAttachmentIdsSet.add(existingAttachment.id);
+          }
+
+          return isDeleted;
+        },
+      );
+
+      await this.attachmentRepository.bulkDelete(deletedAttachments);
+    }
+  }
+}

--- a/src/features/attachment/applications/event-handlers/update-thumbnail-attachment-when-blog-post-updated.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/update-thumbnail-attachment-when-blog-post-updated.domain-event-handler.ts
@@ -1,0 +1,81 @@
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
+import { BlogPostThumbnailImagePathUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-thumbnail-imgae-path-updated.domain-event';
+import { isNil } from '@libs/utils/util';
+import { Propagation, Transactional } from '@nestjs-cls/transactional';
+import { Inject, Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class UpdateThumbnailAttachmentWhenBlogPostUpdatedDomainEventHandler {
+  constructor(
+    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly attachmentRepository: AttachmentRepositoryPort,
+  ) {}
+
+  @OnEvent(BlogPostThumbnailImagePathUpdatedDomainEvent.name, {
+    async: true,
+  })
+  @Transactional(Propagation.RequiresNew)
+  async handle(event: BlogPostThumbnailImagePathUpdatedDomainEvent) {
+    const {
+      oldThumbnailImagePath,
+      newThumbnailImagePath,
+      attachmentUrl,
+      attachmentPath,
+    } = event;
+
+    if (oldThumbnailImagePath === newThumbnailImagePath) {
+      return;
+    }
+
+    if (!isNil(newThumbnailImagePath)) {
+      if (!isNil(oldThumbnailImagePath)) {
+        await this.deleteOldAttachment(
+          oldThumbnailImagePath as string,
+          attachmentPath,
+        );
+      }
+
+      const attachmentId = BigInt(
+        newThumbnailImagePath.replace(attachmentPath, ''),
+      );
+
+      const existingAttachment =
+        await this.attachmentRepository.findOneById(attachmentId);
+
+      if (isNil(existingAttachment)) {
+        return;
+      }
+
+      existingAttachment.changeLocation({
+        path: newThumbnailImagePath,
+        url: `${attachmentUrl}/${newThumbnailImagePath}`,
+      });
+
+      await this.attachmentRepository.update(existingAttachment);
+    } else {
+      await this.deleteOldAttachment(
+        oldThumbnailImagePath as string,
+        attachmentPath,
+      );
+    }
+  }
+
+  private async deleteOldAttachment(
+    oldThumbnailImagePath: string,
+    attachmentPath: string,
+  ) {
+    const attachmentId = BigInt(
+      oldThumbnailImagePath.replace(attachmentPath, ''),
+    );
+
+    const existingAttachment =
+      await this.attachmentRepository.findOneById(attachmentId);
+
+    if (!isNil(existingAttachment)) {
+      existingAttachment.delete();
+      await this.attachmentRepository.delete(existingAttachment);
+    }
+  }
+}

--- a/src/features/attachment/attachment.module.ts
+++ b/src/features/attachment/attachment.module.ts
@@ -12,6 +12,7 @@ import { DeleteAttachmentDomainEventHandler } from '@features/attachment/applica
 import { CreateAttachmentWhenBlogCreatedDomainEventHandler } from '@features/attachment/applications/event-handlers/create-attachment-when-blog-created.domain-event-handler';
 import { UpdateAttachmentWhenBlogBackgroundImageUpdatedDomainEventHandler } from '@features/attachment/applications/event-handlers/update-attachment-when-blog-background-image-updated.domain-event-handler';
 import { UpdateAttachmentWhenUserProfileImageUpdatedDomainEventHandler } from '@features/attachment/applications/event-handlers/update-attachment-when-user-profile-image-updated.domain-event-handler';
+import { CreateThumbnailAttachmentWhenBlogPostCreatedDomainEventHandler } from '@features/attachment/applications/event-handlers/create-thumbnail-attachment-when-blog-post-created.domain-event-handler';
 
 const controllers = [AttachmentController];
 
@@ -33,6 +34,7 @@ const eventHandlers: Provider[] = [
   CreateAttachmentWhenBlogCreatedDomainEventHandler,
   UpdateAttachmentWhenBlogBackgroundImageUpdatedDomainEventHandler,
   UpdateAttachmentWhenUserProfileImageUpdatedDomainEventHandler,
+  CreateThumbnailAttachmentWhenBlogPostCreatedDomainEventHandler,
 ];
 
 @Module({

--- a/src/features/attachment/attachment.module.ts
+++ b/src/features/attachment/attachment.module.ts
@@ -13,6 +13,8 @@ import { CreateAttachmentWhenBlogCreatedDomainEventHandler } from '@features/att
 import { UpdateAttachmentWhenBlogBackgroundImageUpdatedDomainEventHandler } from '@features/attachment/applications/event-handlers/update-attachment-when-blog-background-image-updated.domain-event-handler';
 import { UpdateAttachmentWhenUserProfileImageUpdatedDomainEventHandler } from '@features/attachment/applications/event-handlers/update-attachment-when-user-profile-image-updated.domain-event-handler';
 import { CreateThumbnailAttachmentWhenBlogPostCreatedDomainEventHandler } from '@features/attachment/applications/event-handlers/create-thumbnail-attachment-when-blog-post-created.domain-event-handler';
+import { DeleteAttachmentsWhenBlogPostUpdatedDomainEventHandler } from '@features/attachment/applications/event-handlers/delete-attachments-when-blog-post-updated.domain-event-hanlder';
+import { UpdateThumbnailAttachmentWhenBlogPostUpdatedDomainEventHandler } from '@features/attachment/applications/event-handlers/update-thumbnail-attachment-when-blog-post-updated.domain-event-handler';
 
 const controllers = [AttachmentController];
 
@@ -35,6 +37,8 @@ const eventHandlers: Provider[] = [
   UpdateAttachmentWhenBlogBackgroundImageUpdatedDomainEventHandler,
   UpdateAttachmentWhenUserProfileImageUpdatedDomainEventHandler,
   CreateThumbnailAttachmentWhenBlogPostCreatedDomainEventHandler,
+  DeleteAttachmentsWhenBlogPostUpdatedDomainEventHandler,
+  UpdateThumbnailAttachmentWhenBlogPostUpdatedDomainEventHandler,
 ];
 
 @Module({

--- a/src/features/attachment/domain/attachment.entity.ts
+++ b/src/features/attachment/domain/attachment.entity.ts
@@ -28,7 +28,7 @@ export class AttachmentEntity extends AggregateRoot<AttachmentProps> {
 
   static readonly ATTACHMENT_PATH_PREFIX: string = 'temp/';
 
-  static readonly ATTACHMENT_URL = process.env.ATTACHMENT_URL;
+  static readonly ATTACHMENT_URL = process.env.ATTACHMENT_URL as string;
 
   static create(
     create: CreateAttachmentProps,

--- a/src/features/attachment/domain/attachment.entity.ts
+++ b/src/features/attachment/domain/attachment.entity.ts
@@ -76,9 +76,13 @@ export class AttachmentEntity extends AggregateRoot<AttachmentProps> {
 
   changeLocation(update: UpdateLocationProps): void {
     const newLocation = new Location({
-      path: update.path,
       url: update.url,
+      path: update.path,
     });
+
+    if (this.props.location.equals(newLocation)) {
+      return;
+    }
 
     this.addEvent(
       new AttachmentLocationChangedDomainEvent({

--- a/src/features/blog-post/application/event-handlers/create-contents-attachments-when-blog-post-created.domain-event-handler.ts
+++ b/src/features/blog-post/application/event-handlers/create-contents-attachments-when-blog-post-created.domain-event-handler.ts
@@ -1,0 +1,85 @@
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
+import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
+import { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
+import { BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-attachment/tokens/di.token';
+import { BlogPostCreatedDomainEvent } from '@features/blog-post/domain/events/blog-post-created.domain-event';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
+import { Inject, Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class CreateContentsAttachmentsWhenBlogPostCreatedDomainEventHandler {
+  constructor(
+    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly attachmentRepository: AttachmentRepositoryPort,
+
+    @Inject(BLOG_POST_REPOSITORY_DI_TOKEN)
+    private readonly blogPostRepository: BlogPostRepositoryPort,
+    @Inject(BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly blogPostAttachmentRepository: BlogPostAttachmentRepositoryPort,
+  ) {}
+
+  @OnEvent(BlogPostCreatedDomainEvent.name, {
+    async: true,
+  })
+  async handle(event: BlogPostCreatedDomainEvent) {
+    const { contents, fileUrls } = event;
+
+    const attachments = await this.attachmentRepository.findByUrls(fileUrls);
+
+    const changedUrlInfos: {
+      oldAttachmentUrl: string;
+      newAttachmentUrl: string;
+    }[] = [];
+
+    if (!attachments.length) {
+      return;
+    }
+
+    attachments.forEach((attachment) => {
+      const movedPath =
+        BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_PATH_PREFIX +
+        attachment.id;
+      const movedUrl = `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${movedPath}`;
+
+      changedUrlInfos.push({
+        oldAttachmentUrl: attachment.url,
+        newAttachmentUrl: movedUrl,
+      });
+
+      attachment.changeLocation({
+        path: movedPath,
+        url: movedUrl,
+      });
+    });
+
+    await Promise.all(
+      attachments.map(
+        async (attachment) =>
+          await this.attachmentRepository.update(attachment),
+      ),
+    );
+
+    let jsonContents = JSON.stringify(contents);
+
+    changedUrlInfos.forEach(({ oldAttachmentUrl, newAttachmentUrl }) => {
+      jsonContents = jsonContents.replace(oldAttachmentUrl, newAttachmentUrl);
+    });
+
+    await this.blogPostRepository.updateContents(
+      event.aggregateId,
+      JSON.parse(jsonContents),
+    );
+
+    const blogPostAttachments = attachments.map((attachment) =>
+      BlogPostAttachmentEntity.create({
+        blogPostId: event.aggregateId,
+        attachmentId: attachment.id,
+      }),
+    );
+
+    await this.blogPostAttachmentRepository.bulkCreate(blogPostAttachments);
+  }
+}

--- a/src/features/blog-post/application/event-handlers/create-contents-attachments-when-blog-post-created.domain-event-handler.ts
+++ b/src/features/blog-post/application/event-handlers/create-contents-attachments-when-blog-post-created.domain-event-handler.ts
@@ -6,6 +6,7 @@ import { BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/bl
 import { BlogPostCreatedDomainEvent } from '@features/blog-post/domain/events/blog-post-created.domain-event';
 import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
+import { Propagation, Transactional } from '@nestjs-cls/transactional';
 import { Inject, Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 
@@ -24,6 +25,7 @@ export class CreateContentsAttachmentsWhenBlogPostCreatedDomainEventHandler {
   @OnEvent(BlogPostCreatedDomainEvent.name, {
     async: true,
   })
+  @Transactional(Propagation.RequiresNew)
   async handle(event: BlogPostCreatedDomainEvent) {
     const { contents, fileUrls } = event;
 

--- a/src/features/blog-post/application/event-handlers/create-tags-when-blog-post-created.domain-event-handler.ts
+++ b/src/features/blog-post/application/event-handlers/create-tags-when-blog-post-created.domain-event-handler.ts
@@ -1,0 +1,42 @@
+import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
+import { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port';
+import { BLOG_POST_TAG_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-tag/tokens/di.token';
+import { BlogPostCreatedDomainEvent } from '@features/blog-post/domain/events/blog-post-created.domain-event';
+import { CreateNewTagsCommand } from '@features/tag/commands/create-new-tags/create-new-tags.command';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { Inject, Injectable } from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class CreateTagsWhenBlogPostCreatedDomainEventHandler {
+  constructor(
+    private readonly commandBus: CommandBus,
+
+    @Inject(BLOG_POST_TAG_REPOSITORY_DI_TOKEN)
+    private readonly blogPostTagRepository: BlogPostTagRepositoryPort,
+  ) {}
+
+  @OnEvent(BlogPostCreatedDomainEvent.name, {
+    suppressErrors: false,
+  })
+  async handle(event: BlogPostCreatedDomainEvent) {
+    const { tagNames, userId, aggregateId } = event;
+
+    const command = new CreateNewTagsCommand({
+      userId,
+      tagNames,
+    });
+
+    const result = await this.commandBus.execute<
+      CreateNewTagsCommand,
+      AggregateID[]
+    >(command);
+
+    await this.blogPostTagRepository.bulkCreate(
+      result.map((tagId) =>
+        BlogPostTagEntity.create({ blogPostId: aggregateId, tagId }),
+      ),
+    );
+  }
+}

--- a/src/features/blog-post/application/event-handlers/update-contents-attachments-when-blog-post-updated.domain-event-handler.ts
+++ b/src/features/blog-post/application/event-handlers/update-contents-attachments-when-blog-post-updated.domain-event-handler.ts
@@ -1,0 +1,102 @@
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
+import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
+import { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
+import { BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-attachment/tokens/di.token';
+import { BlogPostUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-updated.domain-event';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
+import { isNil } from '@libs/utils/util';
+import { Propagation, Transactional } from '@nestjs-cls/transactional';
+import { Inject, Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class UpdateContentsAttachmentsWhenBlogPostUpdatedDomainEventHandler {
+  constructor(
+    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly attachmentRepository: AttachmentRepositoryPort,
+
+    @Inject(BLOG_POST_REPOSITORY_DI_TOKEN)
+    private readonly blogPostRepository: BlogPostRepositoryPort,
+    @Inject(BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN)
+    private readonly blogPostAttachmentRepository: BlogPostAttachmentRepositoryPort,
+  ) {}
+
+  @OnEvent(BlogPostUpdatedDomainEvent.name, {
+    async: true,
+  })
+  @Transactional(Propagation.RequiresNew)
+  async handle(event: BlogPostUpdatedDomainEvent) {
+    const { contents } = event.updatedProps;
+
+    if (isNil(contents)) {
+      return;
+    }
+
+    const { newContents, fileUrls } = contents;
+
+    if (fileUrls?.length) {
+      const uploadedAttachments =
+        await this.attachmentRepository.findByUrls(fileUrls);
+
+      const changedUrlInfos: {
+        oldAttachmentUrl: string;
+        newAttachmentUrl: string;
+      }[] = [];
+
+      if (uploadedAttachments.length) {
+        uploadedAttachments.forEach((attachment) => {
+          const movedPath =
+            BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_PATH_PREFIX +
+            attachment.id;
+          const movedUrl = `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${movedPath}`;
+
+          changedUrlInfos.push({
+            oldAttachmentUrl: attachment.url,
+            newAttachmentUrl: movedUrl,
+          });
+
+          attachment.changeLocation({
+            path: movedPath,
+            url: movedUrl,
+          });
+        });
+
+        await Promise.all(
+          uploadedAttachments.map(
+            async (attachment) =>
+              await this.attachmentRepository.update(attachment),
+          ),
+        );
+
+        let jsonContents = JSON.stringify(newContents);
+
+        changedUrlInfos.forEach(({ oldAttachmentUrl, newAttachmentUrl }) => {
+          jsonContents = jsonContents.replace(
+            oldAttachmentUrl,
+            newAttachmentUrl,
+          );
+        });
+
+        const replacedContents = JSON.parse(jsonContents);
+
+        await this.blogPostRepository.updateContents(
+          event.aggregateId,
+          replacedContents,
+        );
+
+        const newBlogPostAttachments = uploadedAttachments.map((attachment) =>
+          BlogPostAttachmentEntity.create({
+            blogPostId: event.aggregateId,
+            attachmentId: attachment.id,
+          }),
+        );
+
+        await this.blogPostAttachmentRepository.bulkCreate(
+          newBlogPostAttachments,
+        );
+      }
+    }
+  }
+}

--- a/src/features/blog-post/application/event-handlers/update-tags-when-blog-post-updated.domain-event-handler.ts
+++ b/src/features/blog-post/application/event-handlers/update-tags-when-blog-post-updated.domain-event-handler.ts
@@ -1,0 +1,53 @@
+import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
+import { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port';
+import { BLOG_POST_TAG_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-tag/tokens/di.token';
+import { BlogPostUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-updated.domain-event';
+import { CreateNewTagsCommand } from '@features/tag/commands/create-new-tags/create-new-tags.command';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { isNil } from '@libs/utils/util';
+import { Inject, Injectable } from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
+import { OnEvent } from '@nestjs/event-emitter';
+
+@Injectable()
+export class UpdateTagsWhenBlogPostUpdatedDomainEventHandler {
+  constructor(
+    private readonly commandBus: CommandBus,
+
+    @Inject(BLOG_POST_TAG_REPOSITORY_DI_TOKEN)
+    private readonly blogPostTagRepository: BlogPostTagRepositoryPort,
+  ) {}
+
+  @OnEvent(BlogPostUpdatedDomainEvent.name, {
+    suppressErrors: false,
+  })
+  async handle(event: BlogPostUpdatedDomainEvent) {
+    const { updatedProps, userId, aggregateId } = event;
+
+    if (isNil(updatedProps.tagNames)) {
+      return;
+    }
+
+    await this.blogPostTagRepository.bulkDeleteByBlogPostId(aggregateId);
+
+    const { tagNames } = updatedProps;
+
+    if (tagNames.length) {
+      const command = new CreateNewTagsCommand({
+        userId,
+        tagNames,
+      });
+
+      const result = await this.commandBus.execute<
+        CreateNewTagsCommand,
+        AggregateID[]
+      >(command);
+
+      await this.blogPostTagRepository.bulkCreate(
+        result.map((tagId) =>
+          BlogPostTagEntity.create({ blogPostId: aggregateId, tagId }),
+        ),
+      );
+    }
+  }
+}

--- a/src/features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity.ts
+++ b/src/features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity.ts
@@ -10,8 +10,8 @@ import {
 import { AggregateID, Entity } from '@libs/ddd/entity.base';
 
 export class BlogPostAttachmentEntity extends Entity<BlogPostAttachmentProps> {
-  static readonly BLOG_POST_ATTACHMENT_URL =
-    process.env.BLOG_POST_ATTACHMENT_URL;
+  static readonly BLOG_POST_ATTACHMENT_URL = process.env
+    .BLOG_POST_ATTACHMENT_URL as string;
   static readonly BLOG_POST_ATTACHMENT_PATH_PREFIX: string = 'blog-post/';
 
   static create(

--- a/src/features/blog-post/blog-post.module.ts
+++ b/src/features/blog-post/blog-post.module.ts
@@ -25,10 +25,12 @@ import { FindPublicBlogPostsQueryHandler } from '@features/blog-post/queries/fin
 import { BlogPostRepository } from '@features/blog-post/repositories/blog-post.repository';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
 import { BlogModule } from '@features/blog/blog.module';
-import { TagModule } from '@features/tag/tag.module';
 import { UserModule } from '@features/user/user.module';
-import { S3Module } from '@libs/s3/s3.module';
 import { Module, Provider } from '@nestjs/common';
+import { BlogPostDomainService } from '@features/blog-post/domain/domain-services/blog-post.domain-service';
+import { CreateTagsWhenBlogPostCreatedDomainEventHandler } from '@features/blog-post/application/event-handlers/create-tags-when-blog-post-created.domain-event-handler';
+import { CreateContentsAttachmentsWhenBlogPostCreatedDomainEventHandler } from '@features/blog-post/application/event-handlers/create-contents-attachments-when-blog-post-created.domain-event-handler';
+import { TagModule } from '@features/tag/tag.module';
 
 const controllers = [BlogPostController, BlogPostCommentController];
 
@@ -55,7 +57,11 @@ const queryHandlers: Provider[] = [
   FindBlogPostCommentsQueryHandler,
 ];
 
-const eventHandlers: Provider[] = [BlogPostBlogDeletedDomainEventHandler];
+const eventHandlers: Provider[] = [
+  BlogPostBlogDeletedDomainEventHandler,
+  CreateTagsWhenBlogPostCreatedDomainEventHandler,
+  CreateContentsAttachmentsWhenBlogPostCreatedDomainEventHandler,
+];
 
 const repositories: Provider[] = [
   { provide: BLOG_POST_REPOSITORY_DI_TOKEN, useClass: BlogPostRepository },
@@ -73,8 +79,10 @@ const repositories: Provider[] = [
   },
 ];
 
+const domainServices: Provider[] = [BlogPostDomainService];
+
 @Module({
-  imports: [BlogModule, TagModule, UserModule, AttachmentModule, S3Module],
+  imports: [BlogModule, UserModule, AttachmentModule, TagModule],
   controllers: [...controllers],
   providers: [
     ...mappers,
@@ -82,6 +90,7 @@ const repositories: Provider[] = [
     ...queryHandlers,
     ...repositories,
     ...eventHandlers,
+    ...domainServices,
   ],
 })
 export class BlogPostModule {}

--- a/src/features/blog-post/blog-post.module.ts
+++ b/src/features/blog-post/blog-post.module.ts
@@ -30,7 +30,8 @@ import { Module, Provider } from '@nestjs/common';
 import { BlogPostDomainService } from '@features/blog-post/domain/domain-services/blog-post.domain-service';
 import { CreateTagsWhenBlogPostCreatedDomainEventHandler } from '@features/blog-post/application/event-handlers/create-tags-when-blog-post-created.domain-event-handler';
 import { CreateContentsAttachmentsWhenBlogPostCreatedDomainEventHandler } from '@features/blog-post/application/event-handlers/create-contents-attachments-when-blog-post-created.domain-event-handler';
-import { TagModule } from '@features/tag/tag.module';
+import { UpdateContentsAttachmentsWhenBlogPostUpdatedDomainEventHandler } from '@features/blog-post/application/event-handlers/update-contents-attachments-when-blog-post-updated.domain-event-handler';
+import { UpdateTagsWhenBlogPostUpdatedDomainEventHandler } from '@features/blog-post/application/event-handlers/update-tags-when-blog-post-updated.domain-event-handler';
 
 const controllers = [BlogPostController, BlogPostCommentController];
 
@@ -61,6 +62,8 @@ const eventHandlers: Provider[] = [
   BlogPostBlogDeletedDomainEventHandler,
   CreateTagsWhenBlogPostCreatedDomainEventHandler,
   CreateContentsAttachmentsWhenBlogPostCreatedDomainEventHandler,
+  UpdateTagsWhenBlogPostUpdatedDomainEventHandler,
+  UpdateContentsAttachmentsWhenBlogPostUpdatedDomainEventHandler,
 ];
 
 const repositories: Provider[] = [
@@ -82,7 +85,7 @@ const repositories: Provider[] = [
 const domainServices: Provider[] = [BlogPostDomainService];
 
 @Module({
-  imports: [BlogModule, UserModule, AttachmentModule, TagModule],
+  imports: [BlogModule, UserModule, AttachmentModule],
   controllers: [...controllers],
   providers: [
     ...mappers,

--- a/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
@@ -6,23 +6,11 @@ import { isNil } from '@libs/utils/util';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
 import { CreateBlogPostCommand } from '@features/blog-post/commands/create-blog-post/create-blog-post.command';
-import { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
 import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
-import { BLOG_POST_TAG_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-tag/tokens/di.token';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { Transactional } from '@nestjs-cls/transactional';
-import { TAG_REPOSITORY_DI_TOKEN } from '@features/tag/tokens/di.token';
-import { TagRepositoryPort } from '@features/tag/repositories/tag.repository-port';
-import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
-import { TagEntity } from '@features/tag/domain/tag.entity';
-import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
-import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
-import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
-import { BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-attachment/tokens/di.token';
-import { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
-import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
-import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
+import { BlogPostDomainService } from '@features/blog-post/domain/domain-services/blog-post.domain-service';
 
 @CommandHandler(CreateBlogPostCommand)
 export class CreateBlogPostCommandHandler
@@ -31,33 +19,15 @@ export class CreateBlogPostCommandHandler
   constructor(
     @Inject(BLOG_REPOSITORY_DI_TOKEN)
     private readonly blogRepository: BlogRepositoryPort,
-    @Inject(BLOG_POST_TAG_REPOSITORY_DI_TOKEN)
-    private readonly blogPostTagRepository: BlogPostTagRepositoryPort,
     @Inject(BLOG_POST_REPOSITORY_DI_TOKEN)
     private readonly blogPostRepository: BlogPostRepositoryPort,
-    @Inject(TAG_REPOSITORY_DI_TOKEN)
-    private readonly tagRepository: TagRepositoryPort,
-    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
-    private readonly attachmentRepository: AttachmentRepositoryPort,
-    @Inject(BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN)
-    private readonly blogPostAttachmentRepository: BlogPostAttachmentRepositoryPort,
+
+    private readonly blogPostDomainService: BlogPostDomainService,
   ) {}
 
   @Transactional()
   async execute(command: CreateBlogPostCommand): Promise<AggregateID> {
-    const {
-      blogId,
-      userId,
-      title,
-      contents,
-      date,
-      location,
-      tagNames,
-      fileUrls,
-      summary,
-      thumbnailImageUrl,
-      isPublic,
-    } = command;
+    const { blogId } = command;
 
     const blog = await this.blogRepository.findOneById(blogId);
 
@@ -67,111 +37,9 @@ export class CreateBlogPostCommandHandler
       });
     }
 
-    if (!blog.isMember(userId)) {
-      throw new HttpForbiddenException({
-        code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
-      });
-    }
-
-    let thumbnailImagePath: string | null = null;
-
-    if (!isNil(thumbnailImageUrl)) {
-      const existingAttachment = (
-        await this.attachmentRepository.findByUrls([thumbnailImageUrl])
-      )[0];
-
-      if (!isNil(existingAttachment)) {
-        const movedPath =
-          BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_PATH_PREFIX +
-          existingAttachment.id;
-        const movedUrl = `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${movedPath}`;
-
-        existingAttachment.changeLocation({
-          path: movedPath,
-          url: movedUrl,
-        });
-
-        await this.attachmentRepository.update(existingAttachment);
-
-        thumbnailImagePath = movedPath;
-      }
-    }
-
-    const blogPost = BlogPostEntity.create({
-      blogId,
-      userId,
-      title,
-      contents,
-      date,
-      location,
-      summary,
-      thumbnailImagePath,
-      isPublic,
-    });
-
-    const tags = await this.tagRepository.findByNames(tagNames);
-    const existingTagNamesSet = new Set(tags.map((tag) => tag.name));
-    const newTagNames = tagNames.filter(
-      (name) => !existingTagNamesSet.has(name),
-    );
-
-    const newTagEntities = newTagNames.map((name) =>
-      TagEntity.create({ name, userId }),
-    );
-
-    await this.tagRepository.bulkCreate(newTagEntities);
-    tags.push(...newTagEntities);
-
-    const blogPostTags = tags.map((tag) => blogPost.createBlogPostTag(tag));
-
-    const attachments = await this.attachmentRepository.findByUrls(fileUrls);
-
-    const changedUrlInfos: {
-      oldAttachmentUrl: string;
-      newAttachmentUrl: string;
-    }[] = [];
-
-    if (attachments.length) {
-      attachments.forEach((attachment) => {
-        const movedPath =
-          BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_PATH_PREFIX +
-          attachment.id;
-        const movedUrl = `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${movedPath}`;
-
-        changedUrlInfos.push({
-          oldAttachmentUrl: attachment.url,
-          newAttachmentUrl: movedUrl,
-        });
-
-        attachment.changeLocation({
-          path: movedPath,
-          url: movedUrl,
-        });
-      });
-
-      await Promise.all(
-        attachments.map(
-          async (attachment) =>
-            await this.attachmentRepository.update(attachment),
-        ),
-      );
-
-      let jsonContents = JSON.stringify(blogPost.contents);
-
-      changedUrlInfos.forEach(({ oldAttachmentUrl, newAttachmentUrl }) => {
-        jsonContents = jsonContents.replace(oldAttachmentUrl, newAttachmentUrl);
-      });
-
-      blogPost.update({ contents: JSON.parse(jsonContents) });
-    }
-
-    const blogPostAttachments = attachments.map((attachment) =>
-      blogPost.createBlogPostAttachment(attachment),
-    );
+    const blogPost = this.blogPostDomainService.create(blog, command);
 
     await this.blogPostRepository.create(blogPost);
-    await this.blogPostTagRepository.bulkCreate(blogPostTags);
-    await this.blogPostAttachmentRepository.bulkCreate(blogPostAttachments);
 
     return blogPost.id;
   }

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
@@ -17,8 +17,6 @@ import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { TagEntity } from '@features/tag/domain/tag.entity';
 import { TagRepositoryPort } from '@features/tag/repositories/tag.repository-port';
 import { TAG_REPOSITORY_DI_TOKEN } from '@features/tag/tokens/di.token';
-import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
-import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
@@ -36,8 +34,6 @@ export class PatchUpdateBlogPostCommandHandler
   constructor(
     @Inject(BLOG_REPOSITORY_DI_TOKEN)
     private readonly blogRepository: BlogRepositoryPort,
-    @Inject(USER_CONNECTION_REPOSITORY_DI_TOKEN)
-    private readonly userConnectionRepository: UserConnectionRepositoryPort,
     @Inject(BLOG_POST_REPOSITORY_DI_TOKEN)
     private readonly blogPostRepository: BlogPostRepositoryPort,
     @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
@@ -1,27 +1,11 @@
-import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
-import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
-import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
-import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
-import { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
-import { BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-attachment/tokens/di.token';
-import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
-import { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port';
-import { BLOG_POST_TAG_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-tag/tokens/di.token';
 import { PatchUpdateBlogPostCommand } from '@features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command';
-import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
-import { UpdateBlogPostProps } from '@features/blog-post/domain/blog-post.entity-interface';
+import { BlogPostDomainService } from '@features/blog-post/domain/domain-services/blog-post.domain-service';
 import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
 import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
-import { TagEntity } from '@features/tag/domain/tag.entity';
-import { TagRepositoryPort } from '@features/tag/repositories/tag.repository-port';
-import { TAG_REPOSITORY_DI_TOKEN } from '@features/tag/tokens/di.token';
-import { AggregateID } from '@libs/ddd/entity.base';
-import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
-import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
@@ -36,44 +20,19 @@ export class PatchUpdateBlogPostCommandHandler
     private readonly blogRepository: BlogRepositoryPort,
     @Inject(BLOG_POST_REPOSITORY_DI_TOKEN)
     private readonly blogPostRepository: BlogPostRepositoryPort,
-    @Inject(ATTACHMENT_REPOSITORY_DI_TOKEN)
-    private readonly attachmentRepository: AttachmentRepositoryPort,
-    @Inject(TAG_REPOSITORY_DI_TOKEN)
-    private readonly tagRepository: TagRepositoryPort,
-    @Inject(BLOG_POST_TAG_REPOSITORY_DI_TOKEN)
-    private readonly blogPostTagRepository: BlogPostTagRepositoryPort,
-    @Inject(BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN)
-    private readonly blogPostAttachmentRepository: BlogPostAttachmentRepositoryPort,
+
+    private readonly blogPostDomainService: BlogPostDomainService,
   ) {}
 
   @Transactional()
   async execute(command: PatchUpdateBlogPostCommand): Promise<void> {
-    const {
-      blogId,
-      blogPostId,
-      userId,
-      title,
-      contents,
-      date,
-      location,
-      isPublic,
-      tagNames,
-      fileUrls,
-      summary,
-      thumbnailImageUrl,
-    } = command;
+    const { blogId, blogPostId, userId } = command;
 
     const blog = await this.blogRepository.findOneById(blogId);
 
     if (isNil(blog)) {
       throw new HttpNotFoundException({
         code: COMMON_ERROR_CODE.RESOURCE_NOT_FOUND,
-      });
-    }
-
-    if (!blog.isMember(userId)) {
-      throw new HttpForbiddenException({
-        code: USER_CONNECTION_ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION,
       });
     }
 
@@ -88,194 +47,17 @@ export class PatchUpdateBlogPostCommandHandler
       });
     }
 
-    const newBlogPostTags: BlogPostTagEntity[] = [];
-    const newBlogPostAttachments: BlogPostAttachmentEntity[] = [];
-
-    if (isPublic === true) {
-      blogPost.switchToPublic();
-    } else if (isPublic === false) {
-      blogPost.switchToPrivate();
-    }
-
-    const updateProps: UpdateBlogPostProps = {
-      title,
-      date,
-      location,
-      summary,
-    };
-
-    if (!isNil(contents)) {
-      const attachmentIds = blogPost.blogPostAttachments.map(
-        (blogPostAttachment) => blogPostAttachment.attachmentId,
-      );
-
-      const existingAttachments =
-        await this.attachmentRepository.findByIdsAndUploadType(
-          attachmentIds,
-          AttachmentUploadType.IMAGE,
-        );
-
-      const jsonContents = JSON.stringify(contents);
-
-      const deletedAttachmentIdsSet = new Set<AggregateID>();
-
-      const deletedAttachments = existingAttachments.filter(
-        (existingAttachment) => {
-          const isDeleted = !jsonContents.includes(existingAttachment.url);
-
-          if (isDeleted) {
-            existingAttachment.delete();
-            deletedAttachmentIdsSet.add(existingAttachment.id);
+    this.blogPostDomainService.update(blog, blogPost, userId, {
+      ...command,
+      contentInfo: command.contents
+        ? {
+            contents: command.contents,
+            fileUrls: command.fileUrls,
+            blogPostAttachments: blogPost.blogPostAttachments,
           }
+        : undefined,
+    });
 
-          return isDeleted;
-        },
-      );
-
-      await this.attachmentRepository.bulkDelete(deletedAttachments);
-
-      const deletedBlogPostAttachments = blogPost.blogPostAttachments.filter(
-        (blogPostAttachment) =>
-          deletedAttachmentIdsSet.has(blogPostAttachment.attachmentId),
-      );
-
-      deletedBlogPostAttachments.forEach((blogPostAttachment) =>
-        blogPost.deleteBlogPostAttachment(blogPostAttachment),
-      );
-
-      updateProps.contents = contents;
-    }
-
-    if (!isNil(tagNames)) {
-      await this.blogPostTagRepository.bulkDeleteByBlogPostId(blogPostId);
-
-      if (tagNames.length) {
-        const tags = await this.tagRepository.findByNames(tagNames);
-        const existingTagNamesSet = new Set(tags.map((tag) => tag.name));
-        const newTagNames = tagNames.filter(
-          (name) => !existingTagNamesSet.has(name),
-        );
-
-        const newTagEntities = newTagNames.map((name) =>
-          TagEntity.create({ name, userId }),
-        );
-
-        await this.tagRepository.bulkCreate(newTagEntities);
-        tags.push(...newTagEntities);
-
-        newBlogPostTags.push(
-          ...tags.map((tag) => blogPost.createBlogPostTag(tag)),
-        );
-      }
-    }
-
-    if (fileUrls?.length) {
-      const uploadedAttachments =
-        await this.attachmentRepository.findByUrls(fileUrls);
-
-      const changedUrlInfos: {
-        oldAttachmentUrl: string;
-        newAttachmentUrl: string;
-      }[] = [];
-
-      if (uploadedAttachments.length) {
-        uploadedAttachments.forEach((attachment) => {
-          const movedPath =
-            BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_PATH_PREFIX +
-            attachment.id;
-          const movedUrl = `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${movedPath}`;
-
-          changedUrlInfos.push({
-            oldAttachmentUrl: attachment.url,
-            newAttachmentUrl: movedUrl,
-          });
-
-          attachment.changeLocation({
-            path: movedPath,
-            url: movedUrl,
-          });
-        });
-
-        await Promise.all(
-          uploadedAttachments.map(
-            async (attachment) =>
-              await this.attachmentRepository.update(attachment),
-          ),
-        );
-
-        if (!isNil(contents)) {
-          let jsonContents = JSON.stringify(contents);
-
-          changedUrlInfos.forEach(({ oldAttachmentUrl, newAttachmentUrl }) => {
-            jsonContents = jsonContents.replace(
-              oldAttachmentUrl,
-              newAttachmentUrl,
-            );
-          });
-
-          updateProps.contents = JSON.parse(jsonContents);
-        }
-      }
-
-      newBlogPostAttachments.push(
-        ...uploadedAttachments.map((attachment) =>
-          blogPost.createBlogPostAttachment(attachment),
-        ),
-      );
-    }
-
-    blogPost.update(updateProps);
-
-    if (thumbnailImageUrl !== undefined) {
-      await this.deleteThumbnailImage(blogPost);
-
-      if (thumbnailImageUrl !== null) {
-        const existingAttachment = (
-          await this.attachmentRepository.findByUrls([thumbnailImageUrl])
-        )[0];
-
-        if (!isNil(existingAttachment)) {
-          const movedPath =
-            BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_PATH_PREFIX +
-            existingAttachment.id;
-          const movedUrl = `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${movedPath}`;
-
-          blogPost.editThumbnailImagePath(movedPath);
-
-          existingAttachment.changeLocation({
-            path: movedPath,
-            url: movedUrl,
-          });
-
-          await this.attachmentRepository.update(existingAttachment);
-        }
-      }
-    }
-
-    await Promise.all([
-      this.blogPostRepository.update(blogPost),
-      this.blogPostTagRepository.bulkCreate(newBlogPostTags),
-      this.blogPostAttachmentRepository.bulkCreate(newBlogPostAttachments),
-    ]);
-  }
-
-  private async deleteThumbnailImage(blogPost: BlogPostEntity): Promise<void> {
-    const thumbnailImageUrl = blogPost.thumbnailImageUrl;
-
-    if (!isNil(thumbnailImageUrl)) {
-      const existingAttachment = (
-        await this.attachmentRepository.findByUrls([thumbnailImageUrl])
-      )[0];
-
-      if (isNil(existingAttachment)) {
-        return;
-      }
-
-      existingAttachment.delete();
-
-      await this.attachmentRepository.delete(existingAttachment);
-
-      blogPost.editThumbnailImagePath(null);
-    }
+    await this.blogPostRepository.update(blogPost);
   }
 }

--- a/src/features/blog-post/domain/blog-post.entity-interface.ts
+++ b/src/features/blog-post/domain/blog-post.entity-interface.ts
@@ -33,8 +33,10 @@ export interface CreateBlogPostProps {
   date: string;
   location: string;
   summary: string;
-  thumbnailImagePath: string | null;
+  thumbnailImageUrl: string | null;
   isPublic: boolean;
+  tagNames: string[];
+  fileUrls: string[];
 }
 
 export interface UpdateBlogPostProps

--- a/src/features/blog-post/domain/blog-post.entity-interface.ts
+++ b/src/features/blog-post/domain/blog-post.entity-interface.ts
@@ -43,6 +43,18 @@ export interface UpdateBlogPostProps
   extends Partial<
     Omit<
       CreateBlogPostProps,
-      'userId' | 'blogId' | 'isPublic' | 'thumbnailImagePath'
+      | 'userId'
+      | 'blogId'
+      | 'isPublic'
+      | 'thumbnailImagePath'
+      | 'contents'
+      | 'fileUrls'
     >
-  > {}
+  > {
+  contentInfo?: {
+    contents: Array<Record<string, any>>;
+    fileUrls?: string[];
+    blogPostAttachments?: BlogPostAttachmentEntity[];
+  };
+  userId: AggregateID;
+}

--- a/src/features/blog-post/domain/blog-post.entity.ts
+++ b/src/features/blog-post/domain/blog-post.entity.ts
@@ -44,7 +44,7 @@ export class BlogPostEntity extends AggregateRoot<BlogPostProps> {
 
     const thumbnailImagePath = thumbnailImageUrl
       ? thumbnailImageUrl?.replace(
-          BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL,
+          `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/`,
           '',
         )
       : null;

--- a/src/features/blog-post/domain/blog-post.entity.ts
+++ b/src/features/blog-post/domain/blog-post.entity.ts
@@ -40,8 +40,18 @@ export class BlogPostEntity extends AggregateRoot<BlogPostProps> {
 
     const now = new Date();
 
+    const { thumbnailImageUrl, tagNames, fileUrls, ...rest } = create;
+
+    const thumbnailImagePath = thumbnailImageUrl
+      ? thumbnailImageUrl?.replace(
+          BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL,
+          '',
+        )
+      : null;
+
     const props: BlogPostProps = {
-      ...create,
+      ...rest,
+      thumbnailImagePath,
       deletedAt: null,
     };
 
@@ -56,6 +66,12 @@ export class BlogPostEntity extends AggregateRoot<BlogPostProps> {
       new BlogPostCreatedDomainEvent({
         aggregateId: id,
         ...props,
+        thumbnailImageUrl,
+        attachmentPath:
+          BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_PATH_PREFIX,
+        attachmentUrl: BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL,
+        fileUrls,
+        tagNames,
       }),
     );
 

--- a/src/features/blog-post/domain/blog-post.entity.ts
+++ b/src/features/blog-post/domain/blog-post.entity.ts
@@ -10,10 +10,8 @@ import {
 } from '@features/blog-post/domain/blog-post.entity-interface';
 import { AggregateRoot } from '@libs/ddd/aggregate-root.base';
 import { TagEntity } from '@features/tag/domain/tag.entity';
-import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
 import { UserEntity } from '@features/user/domain/user.entity';
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
-import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
 import { isNil } from '@libs/utils/util';
 import { BlogPostCreatedDomainEvent } from '@features/blog-post/domain/events/blog-post-created.domain-event';
 import { BlogPostDeletedDomainEvent } from '@features/blog-post/domain/events/blog-post-deleted.domain-event';
@@ -23,6 +21,8 @@ import {
 } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity-interface';
 import { BlogPostCommentEntity } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity';
 import { AggregateID } from '@libs/ddd/entity.base';
+import { BlogPostUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-updated.domain-event';
+import { BlogPostThumbnailImagePathUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-thumbnail-imgae-path-updated.domain-event';
 
 export class BlogPostEntity extends AggregateRoot<BlogPostProps> {
   static BLOG_POST_TITLE_LENGTH = {
@@ -78,13 +78,38 @@ export class BlogPostEntity extends AggregateRoot<BlogPostProps> {
     return blogPost;
   }
 
-  update(update: Partial<UpdateBlogPostProps>): void {
+  update(update: UpdateBlogPostProps): void {
+    const domainEventProps: {
+      aggregateId: AggregateID;
+      userId: AggregateID;
+      updatedProps: {
+        contents?: {
+          oldContents: Array<Record<string, any>>;
+          newContents: Array<Record<string, any>>;
+          fileUrls?: string[];
+          blogPostAttachments?: BlogPostAttachmentEntity[];
+        };
+        tagNames?: string[];
+      };
+    } = {
+      aggregateId: this.id,
+      userId: update.userId,
+      updatedProps: {},
+    };
+
     if (!isNil(update.title)) {
       this.props.title = update.title;
     }
 
-    if (!isNil(update.contents)) {
-      this.props.contents = update.contents;
+    if (!isNil(update.contentInfo)) {
+      domainEventProps.updatedProps.contents = {
+        oldContents: this.props.contents,
+        newContents: update.contentInfo.contents,
+        fileUrls: update.contentInfo.fileUrls,
+        blogPostAttachments: update.contentInfo.blogPostAttachments,
+      };
+
+      this.props.contents = update.contentInfo.contents;
     }
 
     if (!isNil(update.date)) {
@@ -99,10 +124,33 @@ export class BlogPostEntity extends AggregateRoot<BlogPostProps> {
       this.props.summary = update.summary;
     }
 
+    if (!isNil(update.tagNames)) {
+      domainEventProps.updatedProps.tagNames = update.tagNames;
+    }
+
     this.validate();
+
+    if (Object.keys(domainEventProps.updatedProps).length > 0) {
+      this.addEvent(new BlogPostUpdatedDomainEvent(domainEventProps));
+    }
   }
 
-  editThumbnailImagePath(thumbnailImagePath: string | null): void {
+  updateThumbnailImagePath(thumbnailImagePath: string | null): void {
+    if (thumbnailImagePath === this.props.thumbnailImagePath) {
+      return;
+    }
+
+    this.addEvent(
+      new BlogPostThumbnailImagePathUpdatedDomainEvent({
+        aggregateId: this.id,
+        oldThumbnailImagePath: this.props.thumbnailImagePath,
+        newThumbnailImagePath: thumbnailImagePath,
+        attachmentUrl: BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL,
+        attachmentPath:
+          BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_PATH_PREFIX,
+      }),
+    );
+
     this.props.thumbnailImagePath = thumbnailImagePath;
   }
 
@@ -124,33 +172,6 @@ export class BlogPostEntity extends AggregateRoot<BlogPostProps> {
 
   hydrateTag(tag: TagEntity): void {
     this.props.tags = [...(this.props.tags || []), tag.hydrateProps];
-  }
-
-  createBlogPostTag(tag: TagEntity): BlogPostTagEntity {
-    const blogPostTag = BlogPostTagEntity.create({
-      blogPostId: this.id,
-      tagId: tag.id,
-    });
-
-    this.props.blogPostTags = [...(this.props.blogPostTags || []), blogPostTag];
-
-    return blogPostTag;
-  }
-
-  createBlogPostAttachment(
-    attachment: AttachmentEntity,
-  ): BlogPostAttachmentEntity {
-    const blogPostAttachment = BlogPostAttachmentEntity.create({
-      blogPostId: this.id,
-      attachmentId: attachment.id,
-    });
-
-    this.props.blogPostAttachments = [
-      ...(this.props.blogPostAttachments || []),
-      blogPostAttachment,
-    ];
-
-    return blogPostAttachment;
   }
 
   createBlogPostComment(
@@ -202,22 +223,6 @@ export class BlogPostEntity extends AggregateRoot<BlogPostProps> {
     }
 
     this.props.blogPostComments.splice(index, 1);
-  }
-
-  deleteBlogPostAttachment(blogPostAttachment: BlogPostAttachmentEntity): void {
-    if (isNil(this.props.blogPostAttachments)) {
-      return;
-    }
-
-    const index = this.props.blogPostAttachments.findIndex(
-      (attachment) => attachment.id === blogPostAttachment.id,
-    );
-
-    if (index === -1) {
-      return;
-    }
-
-    this.props.blogPostAttachments.splice(index, 1);
   }
 
   delete(): void {

--- a/src/features/blog-post/domain/domain-services/blog-post.domain-service.ts
+++ b/src/features/blog-post/domain/domain-services/blog-post.domain-service.ts
@@ -1,0 +1,67 @@
+import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
+import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
+import { CreateBlogPostProps } from '@features/blog-post/domain/blog-post.entity-interface';
+import { BlogEntity } from '@features/blog/domain/blog.entity';
+import { NotABlogMemberError } from '@features/blog/domain/blog.errors';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class BlogPostDomainService {
+  create(
+    blog: BlogEntity,
+    create: CreateBlogPostProps & {
+      fileUrls: string[];
+      tagNames: string[];
+    },
+  ) {
+    const {
+      userId,
+      title,
+      contents,
+      date,
+      location,
+      tagNames,
+      fileUrls,
+      summary,
+      thumbnailImageUrl,
+      isPublic,
+    } = create;
+
+    if (!blog.isMember(userId)) {
+      throw new NotABlogMemberError();
+    }
+
+    const blogPost = BlogPostEntity.create({
+      blogId: blog.id,
+      userId,
+      title,
+      contents,
+      date,
+      location,
+      summary,
+      thumbnailImageUrl: thumbnailImageUrl
+        ? this.convertAttachmentUrlToBlogPostUrl(thumbnailImageUrl)
+        : null,
+      isPublic,
+      tagNames,
+      fileUrls,
+    });
+
+    return blogPost;
+  }
+
+  private convertAttachmentUrlToBlogPostUrl(attachmentUrl: string) {
+    const convertedUrl = attachmentUrl
+      .replace(
+        AttachmentEntity.ATTACHMENT_URL,
+        BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL,
+      )
+      .replace(
+        AttachmentEntity.ATTACHMENT_PATH_PREFIX,
+        BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_PATH_PREFIX,
+      );
+
+    return convertedUrl;
+  }
+}

--- a/src/features/blog-post/domain/events/blog-post-created.domain-event.ts
+++ b/src/features/blog-post/domain/events/blog-post-created.domain-event.ts
@@ -3,16 +3,35 @@ import { AggregateID } from '@libs/ddd/entity.base';
 
 export class BlogPostCreatedDomainEvent extends DomainEvent {
   readonly userId: AggregateID;
-  readonly title: string;
   readonly blogId: AggregateID;
+  readonly thumbnailImageUrl: string | null;
+  readonly attachmentUrl: string;
+  readonly attachmentPath: string;
+  readonly tagNames: string[];
+  readonly contents: Array<Record<string, any>>;
+  readonly fileUrls: string[];
 
   constructor(props: DomainEventProps<BlogPostCreatedDomainEvent>) {
     super(props);
 
-    const { userId, title, blogId } = props;
+    const {
+      userId,
+      blogId,
+      thumbnailImageUrl,
+      attachmentPath,
+      attachmentUrl,
+      tagNames,
+      contents,
+      fileUrls,
+    } = props;
 
     this.userId = userId;
-    this.title = title;
     this.blogId = blogId;
+    this.thumbnailImageUrl = thumbnailImageUrl;
+    this.attachmentPath = attachmentPath;
+    this.attachmentUrl = attachmentUrl;
+    this.tagNames = tagNames;
+    this.contents = contents;
+    this.fileUrls = fileUrls;
   }
 }

--- a/src/features/blog-post/domain/events/blog-post-thumbnail-imgae-path-updated.domain-event.ts
+++ b/src/features/blog-post/domain/events/blog-post-thumbnail-imgae-path-updated.domain-event.ts
@@ -1,0 +1,26 @@
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
+
+export class BlogPostThumbnailImagePathUpdatedDomainEvent extends DomainEvent {
+  readonly oldThumbnailImagePath: string | null;
+  readonly newThumbnailImagePath: string | null;
+  readonly attachmentUrl: string;
+  readonly attachmentPath: string;
+
+  constructor(
+    props: DomainEventProps<BlogPostThumbnailImagePathUpdatedDomainEvent>,
+  ) {
+    super(props);
+
+    const {
+      oldThumbnailImagePath,
+      newThumbnailImagePath,
+      attachmentUrl,
+      attachmentPath,
+    } = props;
+
+    this.oldThumbnailImagePath = oldThumbnailImagePath;
+    this.newThumbnailImagePath = newThumbnailImagePath;
+    this.attachmentUrl = attachmentUrl;
+    this.attachmentPath = attachmentPath;
+  }
+}

--- a/src/features/blog-post/domain/events/blog-post-updated.domain-event.ts
+++ b/src/features/blog-post/domain/events/blog-post-updated.domain-event.ts
@@ -1,0 +1,25 @@
+import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
+import { AggregateID } from '@libs/ddd/entity.base';
+
+export class BlogPostUpdatedDomainEvent extends DomainEvent {
+  readonly updatedProps: {
+    contents?: {
+      oldContents: Array<Record<string, any>>;
+      newContents: Array<Record<string, any>>;
+      fileUrls?: string[];
+      blogPostAttachments?: BlogPostAttachmentEntity[];
+    };
+    tagNames?: string[];
+  };
+  readonly userId: AggregateID;
+
+  constructor(props: DomainEventProps<BlogPostUpdatedDomainEvent>) {
+    super(props);
+
+    const { updatedProps, userId } = props;
+
+    this.updatedProps = updatedProps;
+    this.userId = userId;
+  }
+}

--- a/src/features/blog-post/repositories/blog-post.repository-port.ts
+++ b/src/features/blog-post/repositories/blog-post.repository-port.ts
@@ -16,4 +16,11 @@ export interface BlogPostRepositoryPort
     id: AggregateID,
     blogPostCommentId: AggregateID,
   ): Promise<BlogPostEntity | undefined>;
+  /**
+   * @description DomainEvent를 발생시키지 않음.
+   */
+  updateContents(
+    blogPostId: AggregateID,
+    contents: Array<Record<string, any>>,
+  ): Promise<void>;
 }

--- a/src/features/blog-post/repositories/blog-post.repository.ts
+++ b/src/features/blog-post/repositories/blog-post.repository.ts
@@ -137,4 +137,14 @@ export class BlogPostRepository implements BlogPostRepositoryPort {
       this.mapper.toEntity(record as BlogPostWithEntitiesModel),
     );
   }
+
+  async updateContents(
+    id: AggregateID,
+    contents: Array<Record<string, any>>,
+  ): Promise<void> {
+    await this.txHost.tx.blogPost.update({
+      where: { id },
+      data: { contents },
+    });
+  }
 }

--- a/src/features/blog-post/repositories/blog-post.repository.ts
+++ b/src/features/blog-post/repositories/blog-post.repository.ts
@@ -122,6 +122,8 @@ export class BlogPostRepository implements BlogPostRepositoryPort {
       data: record,
     });
 
+    await entity.publishEvents(this.eventEmitter);
+
     return this.mapper.toEntity(updatedRecord as BlogPostWithEntitiesModel);
   }
 

--- a/src/features/blog/domain/blog.errors.ts
+++ b/src/features/blog/domain/blog.errors.ts
@@ -8,3 +8,7 @@ export class CannotCreateBlogWithoutAcceptedConnectionError extends DomainExcept
 export class BlogAlreadyExistsError extends DomainException {
   readonly code = ERROR_CODE.YOU_ALREADY_HAVE_A_BLOG;
 }
+
+export class NotABlogMemberError extends DomainException {
+  readonly code = ERROR_CODE.YOU_ARE_NOT_PART_OF_A_CONNECTION;
+}

--- a/src/features/tag/commands/create-new-tags/create-new-tags.command-handler.ts
+++ b/src/features/tag/commands/create-new-tags/create-new-tags.command-handler.ts
@@ -1,0 +1,37 @@
+import { CreateNewTagsCommand } from '@features/tag/commands/create-new-tags/create-new-tags.command';
+import { TagEntity } from '@features/tag/domain/tag.entity';
+import { TagRepositoryPort } from '@features/tag/repositories/tag.repository-port';
+import { TAG_REPOSITORY_DI_TOKEN } from '@features/tag/tokens/di.token';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { Inject } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+@CommandHandler(CreateNewTagsCommand)
+export class CreateNewTagsCommandHandler
+  implements ICommandHandler<CreateNewTagsCommand, AggregateID[]>
+{
+  constructor(
+    @Inject(TAG_REPOSITORY_DI_TOKEN)
+    private readonly tagRepository: TagRepositoryPort,
+  ) {}
+
+  async execute(command: CreateNewTagsCommand): Promise<AggregateID[]> {
+    const { tagNames, userId } = command;
+
+    const tags = await this.tagRepository.findByNames(tagNames);
+    const existingTagNamesSet = new Set(tags.map((tag) => tag.name));
+    const newTagNames = tagNames.filter(
+      (name) => !existingTagNamesSet.has(name),
+    );
+
+    const newTagEntities = newTagNames.map((name) =>
+      TagEntity.create({ name, userId }),
+    );
+
+    await this.tagRepository.bulkCreate(newTagEntities);
+
+    tags.push(...newTagEntities);
+
+    return tags.map((tag) => tag.id);
+  }
+}

--- a/src/features/tag/commands/create-new-tags/create-new-tags.command.ts
+++ b/src/features/tag/commands/create-new-tags/create-new-tags.command.ts
@@ -1,0 +1,15 @@
+import { Command, CommandProps } from '@libs/ddd/command.base';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
+
+export class CreateNewTagsCommand extends Command implements ICommand {
+  readonly tagNames: string[];
+  readonly userId: AggregateID;
+
+  constructor(props: CommandProps<CreateNewTagsCommand>) {
+    super(props);
+
+    this.tagNames = props.tagNames;
+    this.userId = props.userId;
+  }
+}

--- a/src/features/tag/tag.module.ts
+++ b/src/features/tag/tag.module.ts
@@ -2,14 +2,18 @@ import { Module, Provider } from '@nestjs/common';
 import { TagRepository } from '@features/tag/repositories/tag.repository';
 import { TagMapper } from '@features/tag/mappers/tag.mapper';
 import { TAG_REPOSITORY_DI_TOKEN } from '@features/tag/tokens/di.token';
+import { CreateNewTagsCommandHandler } from '@features/tag/commands/create-new-tags/create-new-tags.command-handler';
 
 const mappers: Provider[] = [TagMapper];
+
+const commandHandlers: Provider[] = [CreateNewTagsCommandHandler];
+
 const repositories: Provider[] = [
   { provide: TAG_REPOSITORY_DI_TOKEN, useClass: TagRepository },
 ];
 
 @Module({
-  providers: [...mappers, ...repositories],
+  providers: [...mappers, ...repositories, ...commandHandlers],
   exports: [...mappers, ...repositories],
 })
 export class TagModule {}


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#170

<!-- 내용 (필수) -->

### Description

BlogPost 생성, 수정 로직을 리팩터링 했습니다.

### To Reviewer

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

작업 사항
- tag, attachment 관련 로직을 전부 eventHandler로 이관
  - tag 관련 로직은 하나의 프로세스(트랜잭션)으로 묶여서 처리되도록 EventHandler 구성
  - attachment 관련 로직은 temp 디렉터리로 업로드 된 파일의 경우 이틀까지는 삭제가 되지 않기 때문에 응답 이후에 글을 보는데 문제가 없습니다. 그래서 temp에서 실제 업로드 되는 path에 대해 변경하는 로직은 비동기로 돌려서 응답 시간을 낮췄습니다.
    - DB 정합성이 깨질 수 있는 작업인데 추후 리소스가 된다면 이벤트 실패 시 재시도할 수 있는 방안을 마련하면 좋을 것 같습니다.
- BlogPostDomainService 생성
- DomainException을 던지도록 수정

일단 로직을 분리하는 것에만 집중해서 코드 퀄리티가 떨어지거나 제대로 된 아키텍처 규칙을 지키지 못한 부분이 있을 수도 있는데 꼼꼼하게 봐주시면 감사하겠습니다