### PR TITLE
이미지 path가 null일 때도 attachment url을 붙여주던 로직 수정

### DIFF
--- a/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query-handler.ts
+++ b/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query-handler.ts
@@ -108,7 +108,9 @@ export class FindBlogPostsFromBlogQueryHandler
       blogPosts: blogPosts.map((blogPost) => {
         return {
           ...blogPost,
-          thumbnailImageUrl: `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${blogPost.thumbnailImagePath}`,
+          thumbnailImageUrl: blogPost.thumbnailImagePath
+            ? `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${blogPost.thumbnailImagePath}`
+            : null,
           tags: blogPost.blogPostTags.map((blogPostTag) => blogPostTag.tag),
         };
       }),

--- a/src/features/blog-post/queries/find-one-blog-post/find-one-blog-post.query-handler.ts
+++ b/src/features/blog-post/queries/find-one-blog-post/find-one-blog-post.query-handler.ts
@@ -70,7 +70,9 @@ export class FindOneBlogPostQueryHandler
       location: blogPost.location,
       isPublic: blogPost.isPublic,
       summary: blogPost.summary,
-      thumbnailImageUrl: `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${blogPost.thumbnailImagePath}`,
+      thumbnailImageUrl: blogPost.thumbnailImagePath
+        ? `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${blogPost.thumbnailImagePath}`
+        : null,
       createdAt: blogPost.createdAt,
       updatedAt: blogPost.updatedAt,
       tags: blogPost.blogPostTags.map((blogPostTag) => {

--- a/src/features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query-handler.ts
+++ b/src/features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query-handler.ts
@@ -82,7 +82,9 @@ export class FindPublicBlogPostsQueryHandler
         return {
           ...blogPost,
           tags: blogPost.blogPostTags.map((blogPostTag) => blogPostTag.tag),
-          thumbnailImageUrl: `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${blogPost.thumbnailImagePath}`,
+          thumbnailImageUrl: blogPost.thumbnailImagePath
+            ? `${BlogPostAttachmentEntity.BLOG_POST_ATTACHMENT_URL}/${blogPost.thumbnailImagePath}`
+            : null,
           blog: {
             ...blogPost.blog,
             members: [

--- a/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
+++ b/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
@@ -67,11 +67,15 @@ export class FindOneBlogByUserIdQueryHandler
       members: [
         {
           ...blog.connection.requesterUser,
-          profileImageUrl: `${UserEntity.USER_ATTACHMENT_URL}/${blog.connection.requesterUser.profileImagePath}`,
+          profileImageUrl: blog.connection.requesterUser.profileImagePath
+            ? `${UserEntity.USER_ATTACHMENT_URL}/${blog.connection.requesterUser.profileImagePath}`
+            : null,
         },
         {
           ...blog.connection.requestedUser,
-          profileImageUrl: `${UserEntity.USER_ATTACHMENT_URL}/${blog.connection.requestedUser.profileImagePath}`,
+          profileImageUrl: blog.connection.requestedUser.profileImagePath
+            ? `${UserEntity.USER_ATTACHMENT_URL}/${blog.connection.requestedUser.profileImagePath}`
+            : null,
         },
       ],
       createdAt: blog.createdAt,

--- a/src/features/user/queries/find-one-user/find-one-user.query-handler.ts
+++ b/src/features/user/queries/find-one-user/find-one-user.query-handler.ts
@@ -36,7 +36,9 @@ export class FindOneUserQueryHandler
 
     return {
       ...user,
-      profileImageUrl: `${UserEntity.USER_ATTACHMENT_URL}/${user.profileImagePath}`,
+      profileImageUrl: user.profileImagePath
+        ? `${UserEntity.USER_ATTACHMENT_URL}/${user.profileImagePath}`
+        : null,
     };
   }
 }


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#193 

<!-- 내용 (필수) -->

### Description

image path가 null일 때도 attachment url을 붙여서 response를 내보내던 문제를 수정했습니다