### PR TITLE
채팅방 입장, 메시지 전송 시에 클라이언트로 ack 전송

### DIFF
--- a/src/features/chat-message/gateways/chat-message.gateway.ts
+++ b/src/features/chat-message/gateways/chat-message.gateway.ts
@@ -136,7 +136,7 @@ export class ChatMessageGateway
 
     socket.join(String(roomId));
     this.logger.log(`[Socket] User ${socket.user.sub} joined room ${roomId}`);
-    return { message: 'Successfully joined room', roomId };
+    return { message: 'Successfully joined room' };
   }
 
   @UsePipes(customValidationPipe)
@@ -168,7 +168,7 @@ export class ChatMessageGateway
     });
 
     this.logger.log(
-      `[Socket] Sending message from ${userId} in room ${roomId}: ${message}`,
+      `[Socket] Sending message from ${userId} in room ${roomId}: ${message}, ${blogPostUrl}`,
     );
 
     await this.commandBus.execute<CreateChatMessageCommand, void>(command);
@@ -181,12 +181,6 @@ export class ChatMessageGateway
       `[Socket] Message emitted to room ${roomId} from ${userId}`,
     );
 
-    return {
-      message: 'Successfully sent message',
-      roomId,
-      senderId: userId,
-      sentMessage: message,
-      blogPostUrl,
-    };
+    return { message: 'Successfully sent message' };
   }
 }


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#196 

<!-- 내용 (필수) -->

### Description
채팅방 입장, 메시지 전송 시에 클라이언트로 ack 전송하는 코드를 추가했습니다.
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer
채팅방 입장, 메시지 전송 시에 클라이언트로 ack 전송하는 코드를 추가하여 클라이언트 측에서 콜백 함수를 통해 채팅방에 올바르게 연결되었는지 확인할 수 있도록 수정합니다.

(클라이언트에서 채팅방에 입장했을 때 예시)
<img width="820" alt="스크린샷 2025-03-21 오후 4 42 07" src="https://github.com/user-attachments/assets/b15faa0c-20fb-4393-ba1c-ee99febcbaf1" />

그리고 소켓 통신 과정 로깅이 부족한거 같아서 로그도 좀 더 추가했습니다.
<!-- 참고한 레퍼런스 링크 (선택) -->

### Reference Link
https://velog.io/@jaegeunsong_1997/NestJS-Web-Socket#%EF%B8%8Fsocket-io-%EC%9D%B4%EB%A1%A0

