### PR TITLE
biome lint rule에서 useImportType 옵션 비활성화

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -42,7 +42,8 @@
         "useAsConstAssertion": "error",
         "useBlockStatements": "off",
         "noInferrableTypes": "off",
-        "useNodejsImportProtocol": "off"
+        "useNodejsImportProtocol": "off",
+        "useImportType": "off"
       },
       "suspicious": {
         "noExplicitAny": "off",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,7 +10,6 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
 import { BootstrapService } from '@src/bootstrap.service';
 import { ClsModule } from 'nestjs-cls';
 import { RequestContextModule } from 'nestjs-request-context';
-import { AppController } from './app.controller';
 
 @Module({
   imports: [
@@ -35,7 +34,7 @@ import { AppController } from './app.controller';
     LibsModule,
     FeaturesModule,
   ],
-  controllers: [AppController],
+  controllers: [],
   providers: [BootstrapService],
 })
 export class AppModule {}

--- a/src/bootstrap.service.ts
+++ b/src/bootstrap.service.ts
@@ -1,7 +1,7 @@
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
+import { Key } from '@libs/core/app-config/types/app-config.type';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { BadRequestExceptionFilter } from '@libs/exceptions/client-errors/filters/bad-request.exception-filter';
 import { HttpClientErrorExceptionFilter } from '@libs/exceptions/client-errors/filters/http-client-error.exception-filter';

--- a/src/features/attachment/applications/event-handlers/create-attachment-when-blog-created.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/create-attachment-when-blog-created.domain-event-handler.ts
@@ -1,5 +1,5 @@
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
-import type { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
 import { BlogCreatedDomainEvent } from '@features/blog/domain/events/blog-created.domain-event';

--- a/src/features/attachment/applications/event-handlers/create-thumbnail-attachment-when-blog-post-created.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/create-thumbnail-attachment-when-blog-post-created.domain-event-handler.ts
@@ -1,4 +1,4 @@
-import type { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { BlogPostCreatedDomainEvent } from '@features/blog-post/domain/events/blog-post-created.domain-event';
 import { isNil } from '@libs/utils/util';

--- a/src/features/attachment/applications/event-handlers/delete-attachment.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/delete-attachment.domain-event-handler.ts
@@ -1,5 +1,5 @@
 import { AttachmentDeletedDomainEvent } from '@features/attachment/domain/events/attachment-deleted.domain-event';
-import type { S3ServicePort } from '@libs/s3/services/s3.service-port';
+import { S3ServicePort } from '@libs/s3/services/s3.service-port';
 import { S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
 import { Inject, Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';

--- a/src/features/attachment/applications/event-handlers/delete-attachments-when-blog-post-updated.domain-event-hanlder.ts
+++ b/src/features/attachment/applications/event-handlers/delete-attachments-when-blog-post-updated.domain-event-hanlder.ts
@@ -1,8 +1,8 @@
-import type { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
 import { BlogPostUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-updated.domain-event';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { isNil } from '@libs/utils/util';
 import { Propagation, Transactional } from '@nestjs-cls/transactional';
 import { Inject, Injectable } from '@nestjs/common';

--- a/src/features/attachment/applications/event-handlers/move-attachment-path.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/move-attachment-path.domain-event-handler.ts
@@ -1,8 +1,8 @@
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
 import { AttachmentLocationChangedDomainEvent } from '@features/attachment/domain/events/attachment-location-changed.domain-event';
-import type { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
-import type { S3ServicePort } from '@libs/s3/services/s3.service-port';
+import { S3ServicePort } from '@libs/s3/services/s3.service-port';
 import { S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
 import { Inject, Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';

--- a/src/features/attachment/applications/event-handlers/update-attachment-when-blog-background-image-updated.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/update-attachment-when-blog-background-image-updated.domain-event-handler.ts
@@ -1,5 +1,5 @@
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
-import type { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
 import { BlogBackgroundImagePathUpdatedDomainEvent } from '@features/blog/domain/events/blog-background-image-updated.domain-event';

--- a/src/features/attachment/applications/event-handlers/update-attachment-when-user-profile-image-updated.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/update-attachment-when-user-profile-image-updated.domain-event-handler.ts
@@ -1,5 +1,5 @@
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
-import type { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
 import { UserProfileImagePathUpdatedDomainEvent } from '@features/user/domain/events/user-profile-image-path-updated.domain-event';

--- a/src/features/attachment/applications/event-handlers/update-thumbnail-attachment-when-blog-post-updated.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/update-thumbnail-attachment-when-blog-post-updated.domain-event-handler.ts
@@ -1,4 +1,4 @@
-import type { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { BlogPostThumbnailImagePathUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-thumbnail-imgae-path-updated.domain-event';
 import { isNil } from '@libs/utils/util';

--- a/src/features/attachment/applications/event-handlers/upload-attachment.domain-event-handler.ts
+++ b/src/features/attachment/applications/event-handlers/upload-attachment.domain-event-handler.ts
@@ -1,5 +1,5 @@
 import { AttachmentCreatedDomainEvent } from '@features/attachment/domain/events/attachment-created.domain-event';
-import type { S3ServicePort } from '@libs/s3/services/s3.service-port';
+import { S3ServicePort } from '@libs/s3/services/s3.service-port';
 import { S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
 import { Inject, Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';

--- a/src/features/attachment/attachment.module.ts
+++ b/src/features/attachment/attachment.module.ts
@@ -13,7 +13,7 @@ import { AttachmentMapper } from '@features/attachment/mappers/attachment.mapper
 import { AttachmentRepository } from '@features/attachment/repositories/attachment.repository';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { S3Module } from '@libs/s3/s3.module';
-import { Module, type Provider } from '@nestjs/common';
+import { Module, Provider } from '@nestjs/common';
 import { NestjsFormDataModule } from 'nestjs-form-data';
 
 const controllers = [AttachmentController];

--- a/src/features/attachment/commands/create-attachments/create-attachments.command-handler.ts
+++ b/src/features/attachment/commands/create-attachments/create-attachments.command-handler.ts
@@ -1,6 +1,6 @@
 import { CreateAttachmentsCommand } from '@features/attachment/commands/create-attachments/create-attachments.command';
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
-import type { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';

--- a/src/features/attachment/commands/create-attachments/create-attachments.command-handler.ts
+++ b/src/features/attachment/commands/create-attachments/create-attachments.command-handler.ts
@@ -4,7 +4,7 @@ import { AttachmentRepositoryPort } from '@features/attachment/repositories/atta
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(CreateAttachmentsCommand)
 export class CreateAttachmentsCommandHandler

--- a/src/features/attachment/commands/create-attachments/create-attachments.command.ts
+++ b/src/features/attachment/commands/create-attachments/create-attachments.command.ts
@@ -1,7 +1,7 @@
-import type { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
+import { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class CreateAttachmentsCommand extends Command implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/attachment/commands/create-attachments/create-attachments.command.ts
+++ b/src/features/attachment/commands/create-attachments/create-attachments.command.ts
@@ -1,5 +1,5 @@
 import { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/attachment/controllers/attachment.controller.ts
+++ b/src/features/attachment/controllers/attachment.controller.ts
@@ -1,12 +1,12 @@
 import { routesV1 } from '@config/app.route';
 import { CreateAttachmentsCommand } from '@features/attachment/commands/create-attachments/create-attachments.command';
 import { ApiAttachment } from '@features/attachment/controllers/attachment.swagger';
-import type { CreateAttachmentRequestBodyDto } from '@features/attachment/dtos/request/create-attachment.request-body-dto';
+import { CreateAttachmentRequestBodyDto } from '@features/attachment/dtos/request/create-attachment.request-body-dto';
 import { ApiInternalServerErrorBuilder } from '@libs/api/decorators/api-internal-server-error-builder.decorator';
 import { User } from '@libs/api/decorators/user.decorator';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { Body, Controller, Post } from '@nestjs/common';
-import type { CommandBus } from '@nestjs/cqrs';
+import { CommandBus } from '@nestjs/cqrs';
 import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { FormDataRequest } from 'nestjs-form-data';
 

--- a/src/features/attachment/controllers/attachment.swagger.ts
+++ b/src/features/attachment/controllers/attachment.swagger.ts
@@ -7,16 +7,13 @@ import {
   ApiOperation,
 } from '@nestjs/swagger';
 
-import type { AttachmentController } from '@features/attachment/controllers/attachment.controller';
+import { AttachmentController } from '@features/attachment/controllers/attachment.controller';
 import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { CustomValidationError } from '@libs/types/custom-validation-errors.type';
-import type {
-  ApiOperationOptionsWithSummary,
-  ApiOperator,
-} from '@libs/types/type';
+import { ApiOperationOptionsWithSummary, ApiOperator } from '@libs/types/type';
 
 export const ApiAttachment: ApiOperator<keyof AttachmentController> = {
   Create: (

--- a/src/features/attachment/domain/attachment.entity-interface.ts
+++ b/src/features/attachment/domain/attachment.entity-interface.ts
@@ -1,6 +1,6 @@
-import type { Location } from '@features/attachment/domain/value-objects/location.value-object';
-import type { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { Location } from '@features/attachment/domain/value-objects/location.value-object';
+import { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export interface AttachmentProps {
   userId: AggregateID;

--- a/src/features/attachment/domain/attachment.entity.ts
+++ b/src/features/attachment/domain/attachment.entity.ts
@@ -1,6 +1,6 @@
 import { AggregateRoot } from '@libs/ddd/aggregate-root.base';
 
-import type {
+import {
   AttachmentProps,
   CreateAttachmentProps,
 } from '@features/attachment/domain/attachment.entity-interface';

--- a/src/features/attachment/domain/attachment.entity.ts
+++ b/src/features/attachment/domain/attachment.entity.ts
@@ -9,7 +9,7 @@ import { AttachmentDeletedDomainEvent } from '@features/attachment/domain/events
 import { AttachmentLocationChangedDomainEvent } from '@features/attachment/domain/events/attachment-location-changed.domain-event';
 import {
   Location,
-  type UpdateLocationProps,
+  UpdateLocationProps,
 } from '@features/attachment/domain/value-objects/location.value-object';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';

--- a/src/features/attachment/domain/events/attachment-created.domain-event.ts
+++ b/src/features/attachment/domain/events/attachment-created.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 
 export class AttachmentCreatedDomainEvent extends DomainEvent {
   readonly userId: bigint;

--- a/src/features/attachment/domain/events/attachment-deleted.domain-event.ts
+++ b/src/features/attachment/domain/events/attachment-deleted.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 
 export class AttachmentDeletedDomainEvent extends DomainEvent {
   readonly path: string;

--- a/src/features/attachment/domain/events/attachment-location-changed.domain-event.ts
+++ b/src/features/attachment/domain/events/attachment-location-changed.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 
 export class AttachmentLocationChangedDomainEvent extends DomainEvent {
   readonly oldPath: string;

--- a/src/features/attachment/dtos/request/create-attachment.request-body-dto.ts
+++ b/src/features/attachment/dtos/request/create-attachment.request-body-dto.ts
@@ -3,7 +3,7 @@ import {
   AttachmentUploadType,
   FILE_ARRAY_SIZE,
 } from '@features/attachment/types/attachment.constant';
-import type { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
+import { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
 import { ArrayMaxSize, ArrayMinSize, IsEnum } from 'class-validator';
 import {
   HasMimeType,

--- a/src/features/attachment/dtos/request/create-attachment.request-body-dto.ts
+++ b/src/features/attachment/dtos/request/create-attachment.request-body-dto.ts
@@ -9,7 +9,7 @@ import {
   HasMimeType,
   IsFiles,
   MaxFileSize,
-  type MemoryStoredFile,
+  MemoryStoredFile,
 } from 'nestjs-form-data';
 
 export class CreateAttachmentRequestBodyDto {

--- a/src/features/attachment/mappers/attachment.mapper.ts
+++ b/src/features/attachment/mappers/attachment.mapper.ts
@@ -1,13 +1,13 @@
-import type { Mapper } from '@libs/ddd/mapper.interface';
+import { Mapper } from '@libs/ddd/mapper.interface';
 import { Injectable } from '@nestjs/common';
 import { z } from 'zod';
 
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
-import type { AttachmentProps } from '@features/attachment/domain/attachment.entity-interface';
+import { AttachmentProps } from '@features/attachment/domain/attachment.entity-interface';
 import { Location } from '@features/attachment/domain/value-objects/location.value-object';
 import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
 import { baseSchema } from '@libs/db/base.schema';
-import type { CreateEntityProps } from '@libs/ddd/entity.base';
+import { CreateEntityProps } from '@libs/ddd/entity.base';
 
 export const attachmentSchema = baseSchema.extend({
   userId: z.bigint(),

--- a/src/features/attachment/repositories/attachment.repository-port.ts
+++ b/src/features/attachment/repositories/attachment.repository-port.ts
@@ -1,7 +1,7 @@
-import type { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
-import type { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { RepositoryPort } from '@libs/ddd/repository.port';
+import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface AttachmentRepositoryPort
   extends RepositoryPort<AttachmentEntity> {

--- a/src/features/attachment/repositories/attachment.repository.ts
+++ b/src/features/attachment/repositories/attachment.repository.ts
@@ -1,13 +1,13 @@
-import type { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
-import type { AttachmentMapper } from '@features/attachment/mappers/attachment.mapper';
-import type { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
-import type { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
+import { AttachmentMapper } from '@features/attachment/mappers/attachment.mapper';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { AttachmentUploadTypeUnion } from '@features/attachment/types/attachment.type';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
-import type { EventEmitter2 } from '@nestjs/event-emitter';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 @Injectable()
 export class AttachmentRepository implements AttachmentRepositoryPort {

--- a/src/features/attachment/types/attachment.type.ts
+++ b/src/features/attachment/types/attachment.type.ts
@@ -1,4 +1,4 @@
-import type { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
-import type { ValueOf } from '@libs/types/type';
+import { AttachmentUploadType } from '@features/attachment/types/attachment.constant';
+import { ValueOf } from '@libs/types/type';
 
 export type AttachmentUploadTypeUnion = ValueOf<typeof AttachmentUploadType>;

--- a/src/features/auth/commands/generate-access-token/generate-access-token.command-handler.ts
+++ b/src/features/auth/commands/generate-access-token/generate-access-token.command-handler.ts
@@ -1,7 +1,7 @@
 import { GenerateAccessTokenCommand } from '@features/auth/commands/generate-access-token/generate-access-token.command';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
-import type { AppJwtServicePort } from '@libs/app-jwt/services/app-jwt.service-port';
+import { AppJwtServicePort } from '@libs/app-jwt/services/app-jwt.service-port';
 import { APP_JWT_SERVICE_DI_TOKEN } from '@libs/app-jwt/tokens/app-jwt.di-token';
 import { TokenType } from '@libs/app-jwt/types/app-jwt.enum';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';

--- a/src/features/auth/commands/generate-access-token/generate-access-token.command-handler.ts
+++ b/src/features/auth/commands/generate-access-token/generate-access-token.command-handler.ts
@@ -8,7 +8,7 @@ import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/except
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(GenerateAccessTokenCommand)
 export class GenerateAccessTokenCommandHandler

--- a/src/features/auth/commands/generate-access-token/generate-access-token.command.ts
+++ b/src/features/auth/commands/generate-access-token/generate-access-token.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/auth/commands/generate-access-token/generate-access-token.command.ts
+++ b/src/features/auth/commands/generate-access-token/generate-access-token.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class GenerateAccessTokenCommand extends Command implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/auth/commands/generate-jwt/generate-jwt.command-handler.ts
+++ b/src/features/auth/commands/generate-jwt/generate-jwt.command-handler.ts
@@ -1,11 +1,11 @@
 import { GenerateJwtCommand } from '@features/auth/commands/generate-jwt/generate-jwt.command';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { UserLoginType } from '@features/user/types/user.constant';
-import type { AppJwtServicePort } from '@libs/app-jwt/services/app-jwt.service-port';
+import { AppJwtServicePort } from '@libs/app-jwt/services/app-jwt.service-port';
 import { APP_JWT_SERVICE_DI_TOKEN } from '@libs/app-jwt/tokens/app-jwt.di-token';
 import { TokenType } from '@libs/app-jwt/types/app-jwt.enum';
-import type { JwtTokens } from '@libs/app-jwt/types/app-jwt.interface';
+import { JwtTokens } from '@libs/app-jwt/types/app-jwt.interface';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';
 import { AUTH_ERROR_CODE } from '@libs/exceptions/types/errors/auth/auth-error-code.constant';
 import { isNil } from '@libs/utils/util';

--- a/src/features/auth/commands/generate-jwt/generate-jwt.command-handler.ts
+++ b/src/features/auth/commands/generate-jwt/generate-jwt.command-handler.ts
@@ -10,7 +10,7 @@ import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/except
 import { AUTH_ERROR_CODE } from '@libs/exceptions/types/errors/auth/auth-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(GenerateJwtCommand)
 export class GenerateJwtCommandHandler

--- a/src/features/auth/commands/generate-jwt/generate-jwt.command.ts
+++ b/src/features/auth/commands/generate-jwt/generate-jwt.command.ts
@@ -1,5 +1,5 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { ICommand } from '@nestjs/cqrs';
 
 export class GenerateJwtCommand extends Command implements ICommand {
   readonly email: string;

--- a/src/features/auth/commands/generate-jwt/generate-jwt.command.ts
+++ b/src/features/auth/commands/generate-jwt/generate-jwt.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { ICommand } from '@nestjs/cqrs';
 
 export class GenerateJwtCommand extends Command implements ICommand {

--- a/src/features/auth/controllers/auth.controller.ts
+++ b/src/features/auth/controllers/auth.controller.ts
@@ -2,21 +2,21 @@ import { routesV1 } from '@config/app.route';
 import { GenerateAccessTokenCommand } from '@features/auth/commands/generate-access-token/generate-access-token.command';
 import { GenerateJwtCommand } from '@features/auth/commands/generate-jwt/generate-jwt.command';
 import { ApiAuth } from '@features/auth/controllers/auth.swagger';
-import type { SignUpRequestBodyDto } from '@features/auth/dtos/request/sign-up.request-body-dto';
+import { SignUpRequestBodyDto } from '@features/auth/dtos/request/sign-up.request-body-dto';
 import { CreateUserCommand } from '@features/user/commands/create-user/create-user.command';
 import { UserLoginType } from '@features/user/types/user.constant';
 import { ApiInternalServerErrorBuilder } from '@libs/api/decorators/api-internal-server-error-builder.decorator';
 import { User } from '@libs/api/decorators/user.decorator';
 import { IdResponseDto } from '@libs/api/dtos/response/id.response-dto';
 import { JwtResponseDto } from '@libs/api/dtos/response/jwt.response-dto';
-import type { JwtTokens } from '@libs/app-jwt/types/app-jwt.interface';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { JwtTokens } from '@libs/app-jwt/types/app-jwt.interface';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { SetGuardType } from '@libs/guards/decorators/set-guard-type.decorator';
 import { BasicTokenGuard } from '@libs/guards/providers/basic-auth.guard';
 import { JwtRefreshTokenAuthGuard } from '@libs/guards/providers/jwt-refresh-token-auth.guard';
 import { GuardType } from '@libs/guards/types/guard.constant';
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
-import type { CommandBus } from '@nestjs/cqrs';
+import { CommandBus } from '@nestjs/cqrs';
 import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('Auth')

--- a/src/features/auth/controllers/auth.swagger.ts
+++ b/src/features/auth/controllers/auth.swagger.ts
@@ -1,4 +1,4 @@
-import type { AuthController } from '@features/auth/controllers/auth.controller';
+import { AuthController } from '@features/auth/controllers/auth.controller';
 import { IdResponseDto } from '@libs/api/dtos/response/id.response-dto';
 import { JwtResponseDto } from '@libs/api/dtos/response/jwt.response-dto';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
@@ -8,10 +8,7 @@ import { AUTH_ERROR_CODE } from '@libs/exceptions/types/errors/auth/auth-error-c
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-code.constant';
 import { CustomValidationError } from '@libs/types/custom-validation-errors.type';
-import type {
-  ApiOperationOptionsWithSummary,
-  ApiOperator,
-} from '@libs/types/type';
+import { ApiOperationOptionsWithSummary, ApiOperator } from '@libs/types/type';
 import { HttpStatus, applyDecorators } from '@nestjs/common';
 import {
   ApiBasicAuth,

--- a/src/features/auth/dtos/request/sign-up.request-body-dto.ts
+++ b/src/features/auth/dtos/request/sign-up.request-body-dto.ts
@@ -2,7 +2,7 @@ import {
   USER_PASSWORD_REGEXP,
   UserMbti,
 } from '@features/user/types/user.constant';
-import type { UserMbtiUnion } from '@features/user/types/user.type';
+import { UserMbtiUnion } from '@features/user/types/user.type';
 import { IsNullable } from '@libs/api/decorators/is-nullable.decorator';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsEnum, Length, Matches } from 'class-validator';

--- a/src/features/blog-post/application/event-handlers/blog-post-blog-deleted.domain-event-handler.ts
+++ b/src/features/blog-post/application/event-handlers/blog-post-blog-deleted.domain-event-handler.ts
@@ -1,4 +1,4 @@
-import type { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
 import { BlogDeletedDomainEvent } from '@features/blog/domain/events/blog-deleted.domain-event';
 import { isNil } from '@libs/utils/util';

--- a/src/features/blog-post/application/event-handlers/create-contents-attachments-when-blog-post-created.domain-event-handler.ts
+++ b/src/features/blog-post/application/event-handlers/create-contents-attachments-when-blog-post-created.domain-event-handler.ts
@@ -1,10 +1,10 @@
-import type { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
-import type { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
+import { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
 import { BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-attachment/tokens/di.token';
 import { BlogPostCreatedDomainEvent } from '@features/blog-post/domain/events/blog-post-created.domain-event';
-import type { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
 import { Propagation, Transactional } from '@nestjs-cls/transactional';
 import { Inject, Injectable } from '@nestjs/common';

--- a/src/features/blog-post/application/event-handlers/create-tags-when-blog-post-created.domain-event-handler.ts
+++ b/src/features/blog-post/application/event-handlers/create-tags-when-blog-post-created.domain-event-handler.ts
@@ -1,11 +1,11 @@
 import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
-import type { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port';
+import { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port';
 import { BLOG_POST_TAG_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-tag/tokens/di.token';
 import { BlogPostCreatedDomainEvent } from '@features/blog-post/domain/events/blog-post-created.domain-event';
 import { CreateNewTagsCommand } from '@features/tag/commands/create-new-tags/create-new-tags.command';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { Inject, Injectable } from '@nestjs/common';
-import type { CommandBus } from '@nestjs/cqrs';
+import { CommandBus } from '@nestjs/cqrs';
 import { OnEvent } from '@nestjs/event-emitter';
 
 @Injectable()

--- a/src/features/blog-post/application/event-handlers/update-contents-attachments-when-blog-post-updated.domain-event-handler.ts
+++ b/src/features/blog-post/application/event-handlers/update-contents-attachments-when-blog-post-updated.domain-event-handler.ts
@@ -1,10 +1,10 @@
-import type { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
+import { AttachmentRepositoryPort } from '@features/attachment/repositories/attachment.repository-port';
 import { ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/attachment/tokens/di.token';
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
-import type { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
+import { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
 import { BLOG_POST_ATTACHMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-attachment/tokens/di.token';
 import { BlogPostUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-updated.domain-event';
-import type { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
 import { isNil } from '@libs/utils/util';
 import { Propagation, Transactional } from '@nestjs-cls/transactional';

--- a/src/features/blog-post/application/event-handlers/update-tags-when-blog-post-updated.domain-event-handler.ts
+++ b/src/features/blog-post/application/event-handlers/update-tags-when-blog-post-updated.domain-event-handler.ts
@@ -1,12 +1,12 @@
 import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
-import type { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port';
+import { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port';
 import { BLOG_POST_TAG_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-tag/tokens/di.token';
 import { BlogPostUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-updated.domain-event';
 import { CreateNewTagsCommand } from '@features/tag/commands/create-new-tags/create-new-tags.command';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { isNil } from '@libs/utils/util';
 import { Inject, Injectable } from '@nestjs/common';
-import type { CommandBus } from '@nestjs/cqrs';
+import { CommandBus } from '@nestjs/cqrs';
 import { OnEvent } from '@nestjs/event-emitter';
 
 @Injectable()

--- a/src/features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity-interface.ts
+++ b/src/features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity-interface.ts
@@ -1,4 +1,4 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export interface BlogPostAttachmentProps {
   blogPostId: AggregateID;

--- a/src/features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity.ts
+++ b/src/features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity.ts
@@ -1,6 +1,6 @@
 import { getTsid } from 'tsid-ts';
 
-import type {
+import {
   BlogPostAttachmentProps,
   CreateBlogPostAttachmentProps,
 } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity-interface';

--- a/src/features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity.ts
+++ b/src/features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity.ts
@@ -4,7 +4,7 @@ import {
   BlogPostAttachmentProps,
   CreateBlogPostAttachmentProps,
 } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity-interface';
-import { type AggregateID, Entity } from '@libs/ddd/entity.base';
+import { AggregateID, Entity } from '@libs/ddd/entity.base';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { Guard } from '@libs/guard';

--- a/src/features/blog-post/blog-post-attachment/mappers/blog-post-attachment.mapper.ts
+++ b/src/features/blog-post/blog-post-attachment/mappers/blog-post-attachment.mapper.ts
@@ -1,8 +1,8 @@
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
-import type { BlogPostAttachmentProps } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity-interface';
+import { BlogPostAttachmentProps } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity-interface';
 import { baseSchema } from '@libs/db/base.schema';
-import type { CreateEntityProps } from '@libs/ddd/entity.base';
-import type { Mapper } from '@libs/ddd/mapper.interface';
+import { CreateEntityProps } from '@libs/ddd/entity.base';
+import { Mapper } from '@libs/ddd/mapper.interface';
 import { Injectable } from '@nestjs/common';
 import { z } from 'zod';
 

--- a/src/features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port.ts
+++ b/src/features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port.ts
@@ -1,5 +1,5 @@
-import type { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
-import type { RepositoryPort } from '@libs/ddd/repository.port';
+import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
+import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface BlogPostAttachmentRepositoryPort
   extends RepositoryPort<BlogPostAttachmentEntity> {

--- a/src/features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository.ts
+++ b/src/features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository.ts
@@ -1,10 +1,10 @@
-import type { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
-import type { BlogPostAttachmentMapper } from '@features/blog-post/blog-post-attachment/mappers/blog-post-attachment.mapper';
-import type { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
+import { BlogPostAttachmentMapper } from '@features/blog-post/blog-post-attachment/mappers/blog-post-attachment.mapper';
+import { BlogPostAttachmentRepositoryPort } from '@features/blog-post/blog-post-attachment/repositories/blog-post-attachment.repository-port';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()

--- a/src/features/blog-post/blog-post-comment/commands/create-blog-post-comment/create-blog-post-comment.command-handler.ts
+++ b/src/features/blog-post/blog-post-comment/commands/create-blog-post-comment/create-blog-post-comment.command-handler.ts
@@ -1,13 +1,13 @@
 import { CreateBlogPostCommentCommand } from '@features/blog-post/blog-post-comment/commands/create-blog-post-comment/create-blog-post-comment.command';
-import type { BlogPostCommentRepositoryPort } from '@features/blog-post/blog-post-comment/repositories/blog-post-comment.repository-port';
+import { BlogPostCommentRepositoryPort } from '@features/blog-post/blog-post-comment/repositories/blog-post-comment.repository-port';
 import { BLOG_POST_COMMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-comment/tokens/di.token';
-import type { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
-import type { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';

--- a/src/features/blog-post/blog-post-comment/commands/create-blog-post-comment/create-blog-post-comment.command-handler.ts
+++ b/src/features/blog-post/blog-post-comment/commands/create-blog-post-comment/create-blog-post-comment.command-handler.ts
@@ -17,7 +17,7 @@ import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-c
 import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(CreateBlogPostCommentCommand)
 export class CreateBlogPostCommentCommandHandler

--- a/src/features/blog-post/blog-post-comment/commands/create-blog-post-comment/create-blog-post-comment.command.ts
+++ b/src/features/blog-post/blog-post-comment/commands/create-blog-post-comment/create-blog-post-comment.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/blog-post/blog-post-comment/commands/create-blog-post-comment/create-blog-post-comment.command.ts
+++ b/src/features/blog-post/blog-post-comment/commands/create-blog-post-comment/create-blog-post-comment.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class CreateBlogPostCommentCommand extends Command implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/blog-post/blog-post-comment/commands/delete-blog-post-comment/delete-blog-post-comment.command-handler.ts
+++ b/src/features/blog-post/blog-post-comment/commands/delete-blog-post-comment/delete-blog-post-comment.command-handler.ts
@@ -8,7 +8,7 @@ import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(DeleteBlogPostCommentCommand)
 export class DeleteBlogPostCommentCommandHandler

--- a/src/features/blog-post/blog-post-comment/commands/delete-blog-post-comment/delete-blog-post-comment.command-handler.ts
+++ b/src/features/blog-post/blog-post-comment/commands/delete-blog-post-comment/delete-blog-post-comment.command-handler.ts
@@ -1,7 +1,7 @@
 import { DeleteBlogPostCommentCommand } from '@features/blog-post/blog-post-comment/commands/delete-blog-post-comment/delete-blog-post-comment.command';
-import type { BlogPostCommentRepositoryPort } from '@features/blog-post/blog-post-comment/repositories/blog-post-comment.repository-port';
+import { BlogPostCommentRepositoryPort } from '@features/blog-post/blog-post-comment/repositories/blog-post-comment.repository-port';
 import { BLOG_POST_COMMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-comment/tokens/di.token';
-import type { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';

--- a/src/features/blog-post/blog-post-comment/commands/delete-blog-post-comment/delete-blog-post-comment.command.ts
+++ b/src/features/blog-post/blog-post-comment/commands/delete-blog-post-comment/delete-blog-post-comment.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/blog-post/blog-post-comment/commands/delete-blog-post-comment/delete-blog-post-comment.command.ts
+++ b/src/features/blog-post/blog-post-comment/commands/delete-blog-post-comment/delete-blog-post-comment.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class DeleteBlogPostCommentCommand extends Command implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/blog-post/blog-post-comment/commands/patch-update-blog-post-comment/patch-update-blog-post-comment.command-handler.ts
+++ b/src/features/blog-post/blog-post-comment/commands/patch-update-blog-post-comment/patch-update-blog-post-comment.command-handler.ts
@@ -1,7 +1,7 @@
 import { PatchUpdateBlogPostCommentCommand } from '@features/blog-post/blog-post-comment/commands/patch-update-blog-post-comment/patch-update-blog-post-comment.command';
-import type { BlogPostCommentRepositoryPort } from '@features/blog-post/blog-post-comment/repositories/blog-post-comment.repository-port';
+import { BlogPostCommentRepositoryPort } from '@features/blog-post/blog-post-comment/repositories/blog-post-comment.repository-port';
 import { BLOG_POST_COMMENT_REPOSITORY_DI_TOKEN } from '@features/blog-post/blog-post-comment/tokens/di.token';
-import type { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';

--- a/src/features/blog-post/blog-post-comment/commands/patch-update-blog-post-comment/patch-update-blog-post-comment.command-handler.ts
+++ b/src/features/blog-post/blog-post-comment/commands/patch-update-blog-post-comment/patch-update-blog-post-comment.command-handler.ts
@@ -8,7 +8,7 @@ import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(PatchUpdateBlogPostCommentCommand)
 export class PatchUpdateBlogPostCommentCommandHandler

--- a/src/features/blog-post/blog-post-comment/commands/patch-update-blog-post-comment/patch-update-blog-post-comment.command.ts
+++ b/src/features/blog-post/blog-post-comment/commands/patch-update-blog-post-comment/patch-update-blog-post-comment.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/blog-post/blog-post-comment/commands/patch-update-blog-post-comment/patch-update-blog-post-comment.command.ts
+++ b/src/features/blog-post/blog-post-comment/commands/patch-update-blog-post-comment/patch-update-blog-post-comment.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class PatchUpdateBlogPostCommentCommand
   extends Command

--- a/src/features/blog-post/blog-post-comment/controllers/blog-post-comment.controller.ts
+++ b/src/features/blog-post/blog-post-comment/controllers/blog-post-comment.controller.ts
@@ -3,23 +3,23 @@ import { CreateBlogPostCommentCommand } from '@features/blog-post/blog-post-comm
 import { DeleteBlogPostCommentCommand } from '@features/blog-post/blog-post-comment/commands/delete-blog-post-comment/delete-blog-post-comment.command';
 import { PatchUpdateBlogPostCommentCommand } from '@features/blog-post/blog-post-comment/commands/patch-update-blog-post-comment/patch-update-blog-post-comment.command';
 import { ApiBlogPostComment } from '@features/blog-post/blog-post-comment/controllers/blog-post-comment.swagger';
-import type { CreateBlogPostCommentRequestBodyDto } from '@features/blog-post/blog-post-comment/dtos/request/create-blog-post-comment.request-body-dto';
-import type { FindBlogPostCommentsRequestQueryDto } from '@features/blog-post/blog-post-comment/dtos/request/find-blog-comments.request-query-dto';
-import type { PatchUpdateBlogPostCommentRequestBodyDto } from '@features/blog-post/blog-post-comment/dtos/request/patch-update-blog-post-comment.request-body-dto';
+import { CreateBlogPostCommentRequestBodyDto } from '@features/blog-post/blog-post-comment/dtos/request/create-blog-post-comment.request-body-dto';
+import { FindBlogPostCommentsRequestQueryDto } from '@features/blog-post/blog-post-comment/dtos/request/find-blog-comments.request-query-dto';
+import { PatchUpdateBlogPostCommentRequestBodyDto } from '@features/blog-post/blog-post-comment/dtos/request/patch-update-blog-post-comment.request-body-dto';
 import { BlogPostCommentResponseDto } from '@features/blog-post/blog-post-comment/dtos/response/blog-post-comment.response-dto';
 import { FindBlogPostCommentsQuery } from '@features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query';
-import type { FindBlogPostCommentsQueryHandler } from '@features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query-handler';
+import { FindBlogPostCommentsQueryHandler } from '@features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query-handler';
 import { HydratedUserResponseDto } from '@features/user/dtos/response/hydrated-user.response-dto';
 import { ApiInternalServerErrorBuilder } from '@libs/api/decorators/api-internal-server-error-builder.decorator';
 import { User } from '@libs/api/decorators/user.decorator';
 import { IdResponseDto } from '@libs/api/dtos/response/id.response-dto';
 import { NotEmptyObjectPipe } from '@libs/api/pipes/not-empty-object.pipe';
 import { ParsePositiveBigIntPipe } from '@libs/api/pipes/parse-positive-int.pipe';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { SetGuardType } from '@libs/guards/decorators/set-guard-type.decorator';
 import { GuardType } from '@libs/guards/types/guard.constant';
 import { SetPagination } from '@libs/interceptors/pagination/decorators/pagination-interceptor.decorator';
-import type { HandlerReturnType } from '@libs/types/type';
+import { HandlerReturnType } from '@libs/types/type';
 import {
   Body,
   Controller,
@@ -32,7 +32,7 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
-import type { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('BlogPostComment')

--- a/src/features/blog-post/blog-post-comment/controllers/blog-post-comment.swagger.ts
+++ b/src/features/blog-post/blog-post-comment/controllers/blog-post-comment.swagger.ts
@@ -10,7 +10,7 @@ import {
   getSchemaPath,
 } from '@nestjs/swagger';
 
-import type { BlogPostCommentController } from '@features/blog-post/blog-post-comment/controllers/blog-post-comment.controller';
+import { BlogPostCommentController } from '@features/blog-post/blog-post-comment/controllers/blog-post-comment.controller';
 import { BlogPostCommentResponseDto } from '@features/blog-post/blog-post-comment/dtos/response/blog-post-comment.response-dto';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
@@ -22,10 +22,7 @@ import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-c
 import { CursorPaginationResponseDto } from '@libs/interceptors/pagination/dtos/cursor-pagination-interceptor.response-dto';
 import { OffsetPaginationResponseDto } from '@libs/interceptors/pagination/dtos/offset-pagination-interceptor.response-dto';
 import { CustomValidationError } from '@libs/types/custom-validation-errors.type';
-import type {
-  ApiOperationOptionsWithSummary,
-  ApiOperator,
-} from '@libs/types/type';
+import { ApiOperationOptionsWithSummary, ApiOperator } from '@libs/types/type';
 export const ApiBlogPostComment: ApiOperator<keyof BlogPostCommentController> =
   {
     Create: (

--- a/src/features/blog-post/blog-post-comment/domain/blog-post-comment.entity-interface.ts
+++ b/src/features/blog-post/blog-post-comment/domain/blog-post-comment.entity-interface.ts
@@ -1,4 +1,4 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export interface BlogPostCommentProps {
   blogPostId: AggregateID;

--- a/src/features/blog-post/blog-post-comment/domain/blog-post-comment.entity.ts
+++ b/src/features/blog-post/blog-post-comment/domain/blog-post-comment.entity.ts
@@ -4,7 +4,7 @@ import {
   BlogPostCommentProps,
   CreateBlogPostCommentProps,
 } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity-interface';
-import { type AggregateID, Entity } from '@libs/ddd/entity.base';
+import { AggregateID, Entity } from '@libs/ddd/entity.base';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { Guard } from '@libs/guard';

--- a/src/features/blog-post/blog-post-comment/domain/blog-post-comment.entity.ts
+++ b/src/features/blog-post/blog-post-comment/domain/blog-post-comment.entity.ts
@@ -1,6 +1,6 @@
 import { getTsid } from 'tsid-ts';
 
-import type {
+import {
   BlogPostCommentProps,
   CreateBlogPostCommentProps,
 } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity-interface';

--- a/src/features/blog-post/blog-post-comment/dtos/request/find-blog-comments.request-query-dto.ts
+++ b/src/features/blog-post/blog-post-comment/dtos/request/find-blog-comments.request-query-dto.ts
@@ -1,8 +1,8 @@
-import type { BlogPostCommentModel } from '@features/blog-post/blog-post-comment/mappers/blog-post-comment.mapper';
+import { BlogPostCommentModel } from '@features/blog-post/blog-post-comment/mappers/blog-post-comment.mapper';
 import { CursorPaginationRequestQueryDto } from '@libs/api/dtos/request/cursor-pagination.request-query-dto';
 import { ParseQueryByColonAndTransformToObject } from '@libs/api/transformers/parse-query-by-colon-and-transform-to-object.transformer';
 import { SortOrder } from '@libs/api/types/api.constant';
-import type { CursorBy, OrderBy } from '@libs/api/types/api.type';
+import { CursorBy, OrderBy } from '@libs/api/types/api.type';
 
 type BlogPostCommentModelForPaginated = Pick<
   BlogPostCommentModel,

--- a/src/features/blog-post/blog-post-comment/dtos/response/blog-post-comment.response-dto.ts
+++ b/src/features/blog-post/blog-post-comment/dtos/response/blog-post-comment.response-dto.ts
@@ -3,7 +3,7 @@ import {
   BaseResponseDto,
   type CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export interface CreateBlogPostCommentResponseDtoProps

--- a/src/features/blog-post/blog-post-comment/dtos/response/blog-post-comment.response-dto.ts
+++ b/src/features/blog-post/blog-post-comment/dtos/response/blog-post-comment.response-dto.ts
@@ -1,7 +1,7 @@
 import { HydratedUserResponseDto } from '@features/user/dtos/response/hydrated-user.response-dto';
 import {
   BaseResponseDto,
-  type CreateBaseResponseDtoProps,
+  CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';

--- a/src/features/blog-post/blog-post-comment/mappers/blog-post-comment.mapper.ts
+++ b/src/features/blog-post/blog-post-comment/mappers/blog-post-comment.mapper.ts
@@ -1,8 +1,8 @@
 import { BlogPostCommentEntity } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity';
-import type { BlogPostCommentProps } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity-interface';
+import { BlogPostCommentProps } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity-interface';
 import { baseSchema } from '@libs/db/base.schema';
-import type { CreateEntityProps } from '@libs/ddd/entity.base';
-import type { Mapper } from '@libs/ddd/mapper.interface';
+import { CreateEntityProps } from '@libs/ddd/entity.base';
+import { Mapper } from '@libs/ddd/mapper.interface';
 import { Injectable } from '@nestjs/common';
 import { z } from 'zod';
 

--- a/src/features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query-handler.ts
+++ b/src/features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query-handler.ts
@@ -8,7 +8,7 @@ import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-c
 import { isNil } from '@libs/utils/util';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
-import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindBlogPostCommentsQuery)
 export class FindBlogPostCommentsQueryHandler

--- a/src/features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query-handler.ts
+++ b/src/features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query-handler.ts
@@ -1,13 +1,13 @@
 import { FindBlogPostCommentsQuery } from '@features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query';
 import { UserEntity } from '@features/user/domain/user.entity';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { isNil } from '@libs/utils/util';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindBlogPostCommentsQuery)

--- a/src/features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query.ts
+++ b/src/features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query.ts
@@ -1,5 +1,5 @@
 import { AggregateID } from '@libs/ddd/entity.base';
-import { type PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
+import { PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
 import { IQuery } from '@nestjs/cqrs';
 
 export class FindBlogPostCommentsQuery

--- a/src/features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query.ts
+++ b/src/features/blog-post/blog-post-comment/queries/find-blog-post-comments/find-blog-post-comments.query.ts
@@ -1,6 +1,6 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { type PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
-import type { IQuery } from '@nestjs/cqrs';
+import { IQuery } from '@nestjs/cqrs';
 
 export class FindBlogPostCommentsQuery
   extends PaginatedQueryBase

--- a/src/features/blog-post/blog-post-comment/repositories/blog-post-comment.repository-port.ts
+++ b/src/features/blog-post/blog-post-comment/repositories/blog-post-comment.repository-port.ts
@@ -1,5 +1,5 @@
-import type { BlogPostCommentEntity } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity';
-import type { RepositoryPort } from '@libs/ddd/repository.port';
+import { BlogPostCommentEntity } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity';
+import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface BlogPostCommentRepositoryPort
   extends RepositoryPort<BlogPostCommentEntity> {}

--- a/src/features/blog-post/blog-post-comment/repositories/blog-post-comment.repository.ts
+++ b/src/features/blog-post/blog-post-comment/repositories/blog-post-comment.repository.ts
@@ -1,10 +1,10 @@
-import type { BlogPostCommentEntity } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity';
-import type { BlogPostCommentMapper } from '@features/blog-post/blog-post-comment/mappers/blog-post-comment.mapper';
-import type { BlogPostCommentRepositoryPort } from '@features/blog-post/blog-post-comment/repositories/blog-post-comment.repository-port';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { BlogPostCommentEntity } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity';
+import { BlogPostCommentMapper } from '@features/blog-post/blog-post-comment/mappers/blog-post-comment.mapper';
+import { BlogPostCommentRepositoryPort } from '@features/blog-post/blog-post-comment/repositories/blog-post-comment.repository-port';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()

--- a/src/features/blog-post/blog-post-tag/domain/blog-post-tag.entity-interface.ts
+++ b/src/features/blog-post/blog-post-tag/domain/blog-post-tag.entity-interface.ts
@@ -1,4 +1,4 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export interface BlogPostTagProps {
   blogPostId: AggregateID;

--- a/src/features/blog-post/blog-post-tag/domain/blog-post-tag.entity.ts
+++ b/src/features/blog-post/blog-post-tag/domain/blog-post-tag.entity.ts
@@ -1,6 +1,6 @@
 import { getTsid } from 'tsid-ts';
 
-import type {
+import {
   BlogPostTagProps,
   CreateBlogPostTagProps,
 } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity-interface';

--- a/src/features/blog-post/blog-post-tag/mappers/blog-post-tag.mapper.ts
+++ b/src/features/blog-post/blog-post-tag/mappers/blog-post-tag.mapper.ts
@@ -1,8 +1,8 @@
 import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
-import type { BlogPostTagProps } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity-interface';
+import { BlogPostTagProps } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity-interface';
 import { baseSchema } from '@libs/db/base.schema';
-import type { CreateEntityProps } from '@libs/ddd/entity.base';
-import type { Mapper } from '@libs/ddd/mapper.interface';
+import { CreateEntityProps } from '@libs/ddd/entity.base';
+import { Mapper } from '@libs/ddd/mapper.interface';
 import { Injectable } from '@nestjs/common';
 import { z } from 'zod';
 

--- a/src/features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port.ts
+++ b/src/features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port.ts
@@ -1,6 +1,6 @@
-import type { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { RepositoryPort } from '@libs/ddd/repository.port';
+import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface BlogPostTagRepositoryPort
   extends RepositoryPort<BlogPostTagEntity> {

--- a/src/features/blog-post/blog-post-tag/repositories/blog-post-tag.repository.ts
+++ b/src/features/blog-post/blog-post-tag/repositories/blog-post-tag.repository.ts
@@ -1,10 +1,10 @@
-import type { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
-import type { BlogPostTagMapper } from '@features/blog-post/blog-post-tag/mappers/blog-post-tag.mapper';
-import type { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
+import { BlogPostTagMapper } from '@features/blog-post/blog-post-tag/mappers/blog-post-tag.mapper';
+import { BlogPostTagRepositoryPort } from '@features/blog-post/blog-post-tag/repositories/blog-post-tag.repository-port';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()

--- a/src/features/blog-post/blog-post.module.ts
+++ b/src/features/blog-post/blog-post.module.ts
@@ -31,7 +31,7 @@ import { BlogPostRepository } from '@features/blog-post/repositories/blog-post.r
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
 import { BlogModule } from '@features/blog/blog.module';
 import { UserModule } from '@features/user/user.module';
-import { Module, type Provider } from '@nestjs/common';
+import { Module, Provider } from '@nestjs/common';
 
 const controllers = [BlogPostController, BlogPostCommentController];
 

--- a/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
@@ -10,7 +10,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(CreateBlogPostCommand)
 export class CreateBlogPostCommandHandler

--- a/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/create-blog-post/create-blog-post.command-handler.ts
@@ -1,10 +1,10 @@
 import { CreateBlogPostCommand } from '@features/blog-post/commands/create-blog-post/create-blog-post.command';
-import type { BlogPostDomainService } from '@features/blog-post/domain/domain-services/blog-post.domain-service';
-import type { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BlogPostDomainService } from '@features/blog-post/domain/domain-services/blog-post.domain-service';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
-import type { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';

--- a/src/features/blog-post/commands/create-blog-post/create-blog-post.command.ts
+++ b/src/features/blog-post/commands/create-blog-post/create-blog-post.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/blog-post/commands/create-blog-post/create-blog-post.command.ts
+++ b/src/features/blog-post/commands/create-blog-post/create-blog-post.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class CreateBlogPostCommand extends Command implements ICommand {
   readonly blogId: AggregateID;

--- a/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command-handler.ts
@@ -11,7 +11,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(DeleteBlogPostCommand)
 export class DeleteBlogPostCommandHandler

--- a/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command-handler.ts
@@ -1,9 +1,9 @@
 import { DeleteBlogPostCommand } from '@features/blog-post/commands/delete-blog-post/delete-blog-post.command';
-import type { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
-import type { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
-import type { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
+import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
 import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';

--- a/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command.ts
+++ b/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command.ts
+++ b/src/features/blog-post/commands/delete-blog-post/delete-blog-post.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class DeleteBlogPostCommand extends Command implements ICommand {
   readonly blogId: AggregateID;

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
@@ -1,8 +1,8 @@
 import { PatchUpdateBlogPostCommand } from '@features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command';
-import type { BlogPostDomainService } from '@features/blog-post/domain/domain-services/blog-post.domain-service';
-import type { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
+import { BlogPostDomainService } from '@features/blog-post/domain/domain-services/blog-post.domain-service';
+import { BlogPostRepositoryPort } from '@features/blog-post/repositories/blog-post.repository-port';
 import { BLOG_POST_REPOSITORY_DI_TOKEN } from '@features/blog-post/tokens/di.token';
-import type { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command-handler.ts
@@ -9,7 +9,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(PatchUpdateBlogPostCommand)
 export class PatchUpdateBlogPostCommandHandler

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command.ts
+++ b/src/features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class PatchUpdateBlogPostCommand extends Command implements ICommand {
   readonly blogId: AggregateID;

--- a/src/features/blog-post/controllers/blog-post.controller.ts
+++ b/src/features/blog-post/controllers/blog-post.controller.ts
@@ -3,17 +3,17 @@ import { CreateBlogPostCommand } from '@features/blog-post/commands/create-blog-
 import { DeleteBlogPostCommand } from '@features/blog-post/commands/delete-blog-post/delete-blog-post.command';
 import { PatchUpdateBlogPostCommand } from '@features/blog-post/commands/patch-update-blog-post/patch-update-blog-post.command';
 import { ApiBlogPost } from '@features/blog-post/controllers/blog-post.swagger';
-import type { CreateBlogPostRequestBodyDto } from '@features/blog-post/dtos/request/create-blog-post.request-body-dto';
-import type { FindBlogPostsFromBlogRequestQueryDto } from '@features/blog-post/dtos/request/find-blog-posts-from-blog.request-query-dto';
-import type { FindPublicBlogPostsRequestQueryDto } from '@features/blog-post/dtos/request/find-public-blog-posts.request-query-dto';
-import type { PatchUpdateBlogPostRequestBodyDto } from '@features/blog-post/dtos/request/patch-update-blog-post.request-body-dto';
+import { CreateBlogPostRequestBodyDto } from '@features/blog-post/dtos/request/create-blog-post.request-body-dto';
+import { FindBlogPostsFromBlogRequestQueryDto } from '@features/blog-post/dtos/request/find-blog-posts-from-blog.request-query-dto';
+import { FindPublicBlogPostsRequestQueryDto } from '@features/blog-post/dtos/request/find-public-blog-posts.request-query-dto';
+import { PatchUpdateBlogPostRequestBodyDto } from '@features/blog-post/dtos/request/patch-update-blog-post.request-body-dto';
 import { BlogPostResponseDto } from '@features/blog-post/dtos/response/blog-post.response-dto';
 import { FindBlogPostsFromBlogQuery } from '@features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query';
-import type { FindBlogPostsFromBlogQueryHandler } from '@features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query-handler';
+import { FindBlogPostsFromBlogQueryHandler } from '@features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query-handler';
 import { FindOneBlogPostQuery } from '@features/blog-post/queries/find-one-blog-post/find-one-blog-post.query';
-import type { FindOneBlogPostQueryHandler } from '@features/blog-post/queries/find-one-blog-post/find-one-blog-post.query-handler';
+import { FindOneBlogPostQueryHandler } from '@features/blog-post/queries/find-one-blog-post/find-one-blog-post.query-handler';
 import { FindPublicBlogPostsQuery } from '@features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query';
-import type { FindPublicBlogPostsQueryHandler } from '@features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query-handler';
+import { FindPublicBlogPostsQueryHandler } from '@features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query-handler';
 import { NotABlogMemberError } from '@features/blog/domain/blog.errors';
 import { HydratedBlogResponseDto } from '@features/blog/dtos/response/hydrated-blog.response-dto';
 import { HydratedTagResponseDto } from '@features/tag/dtos/response/hydrated-tag.response-dto';
@@ -23,12 +23,12 @@ import { User } from '@libs/api/decorators/user.decorator';
 import { IdResponseDto } from '@libs/api/dtos/response/id.response-dto';
 import { NotEmptyObjectPipe } from '@libs/api/pipes/not-empty-object.pipe';
 import { ParsePositiveBigIntPipe } from '@libs/api/pipes/parse-positive-int.pipe';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { SetGuardType } from '@libs/guards/decorators/set-guard-type.decorator';
 import { GuardType } from '@libs/guards/types/guard.constant';
 import { SetPagination } from '@libs/interceptors/pagination/decorators/pagination-interceptor.decorator';
-import type { HandlerReturnType } from '@libs/types/type';
+import { HandlerReturnType } from '@libs/types/type';
 import {
   Body,
   Controller,
@@ -41,7 +41,7 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
-import type { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('BlogPost')

--- a/src/features/blog-post/controllers/blog-post.swagger.ts
+++ b/src/features/blog-post/controllers/blog-post.swagger.ts
@@ -10,7 +10,7 @@ import {
   getSchemaPath,
 } from '@nestjs/swagger';
 
-import type { BlogPostController } from '@features/blog-post/controllers/blog-post.controller';
+import { BlogPostController } from '@features/blog-post/controllers/blog-post.controller';
 import { BlogPostResponseDto } from '@features/blog-post/dtos/response/blog-post.response-dto';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
@@ -21,10 +21,7 @@ import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-c
 import { CursorPaginationResponseDto } from '@libs/interceptors/pagination/dtos/cursor-pagination-interceptor.response-dto';
 import { OffsetPaginationResponseDto } from '@libs/interceptors/pagination/dtos/offset-pagination-interceptor.response-dto';
 import { CustomValidationError } from '@libs/types/custom-validation-errors.type';
-import type {
-  ApiOperationOptionsWithSummary,
-  ApiOperator,
-} from '@libs/types/type';
+import { ApiOperationOptionsWithSummary, ApiOperator } from '@libs/types/type';
 
 export const ApiBlogPost: ApiOperator<keyof BlogPostController> = {
   Create: (

--- a/src/features/blog-post/domain/blog-post.entity-interface.ts
+++ b/src/features/blog-post/domain/blog-post.entity-interface.ts
@@ -1,9 +1,9 @@
-import type { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
-import type { BlogPostCommentEntity } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity';
-import type { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
-import type { HydratedTagEntityProps } from '@features/tag/domain/tag.entity-interface';
-import type { HydratedUserEntityProps } from '@features/user/domain/user.entity-interface';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
+import { BlogPostCommentEntity } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity';
+import { BlogPostTagEntity } from '@features/blog-post/blog-post-tag/domain/blog-post-tag.entity';
+import { HydratedTagEntityProps } from '@features/tag/domain/tag.entity-interface';
+import { HydratedUserEntityProps } from '@features/user/domain/user.entity-interface';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export interface BlogPostProps {
   userId: AggregateID;

--- a/src/features/blog-post/domain/blog-post.entity.ts
+++ b/src/features/blog-post/domain/blog-post.entity.ts
@@ -2,11 +2,11 @@ import { getTsid } from 'tsid-ts';
 
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
 import { BlogPostCommentEntity } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity';
-import type {
+import {
   BlogPostCommentProps,
   CreateBlogPostCommentProps,
 } from '@features/blog-post/blog-post-comment/domain/blog-post-comment.entity-interface';
-import type {
+import {
   BlogPostProps,
   CreateBlogPostProps,
   UpdateBlogPostProps,
@@ -15,10 +15,10 @@ import { BlogPostCreatedDomainEvent } from '@features/blog-post/domain/events/bl
 import { BlogPostDeletedDomainEvent } from '@features/blog-post/domain/events/blog-post-deleted.domain-event';
 import { BlogPostThumbnailImagePathUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-thumbnail-imgae-path-updated.domain-event';
 import { BlogPostUpdatedDomainEvent } from '@features/blog-post/domain/events/blog-post-updated.domain-event';
-import type { TagEntity } from '@features/tag/domain/tag.entity';
-import type { UserEntity } from '@features/user/domain/user.entity';
+import { TagEntity } from '@features/tag/domain/tag.entity';
+import { UserEntity } from '@features/user/domain/user.entity';
 import { AggregateRoot } from '@libs/ddd/aggregate-root.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { Guard } from '@libs/guard';

--- a/src/features/blog-post/domain/domain-services/blog-post.domain-service.ts
+++ b/src/features/blog-post/domain/domain-services/blog-post.domain-service.ts
@@ -1,13 +1,13 @@
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
 import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
-import type {
+import {
   CreateBlogPostProps,
   UpdateBlogPostProps,
 } from '@features/blog-post/domain/blog-post.entity-interface';
-import type { BlogEntity } from '@features/blog/domain/blog.entity';
+import { BlogEntity } from '@features/blog/domain/blog.entity';
 import { NotABlogMemberError } from '@features/blog/domain/blog.errors';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { isNil } from '@libs/utils/util';
 import { Injectable } from '@nestjs/common';
 

--- a/src/features/blog-post/domain/events/blog-post-created.domain-event.ts
+++ b/src/features/blog-post/domain/events/blog-post-created.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 import { AggregateID } from '@libs/ddd/entity.base';
 
 export class BlogPostCreatedDomainEvent extends DomainEvent {

--- a/src/features/blog-post/domain/events/blog-post-created.domain-event.ts
+++ b/src/features/blog-post/domain/events/blog-post-created.domain-event.ts
@@ -2,7 +2,7 @@ import {
   DomainEvent,
   type DomainEventProps,
 } from '@libs/ddd/base-domain.event';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export class BlogPostCreatedDomainEvent extends DomainEvent {
   readonly userId: AggregateID;

--- a/src/features/blog-post/domain/events/blog-post-deleted.domain-event.ts
+++ b/src/features/blog-post/domain/events/blog-post-deleted.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 
 export class BlogPostDeletedDomainEvent extends DomainEvent {
   constructor(props: DomainEventProps<BlogPostDeletedDomainEvent>) {

--- a/src/features/blog-post/domain/events/blog-post-thumbnail-imgae-path-updated.domain-event.ts
+++ b/src/features/blog-post/domain/events/blog-post-thumbnail-imgae-path-updated.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 
 export class BlogPostThumbnailImagePathUpdatedDomainEvent extends DomainEvent {
   readonly oldThumbnailImagePath: string | null;

--- a/src/features/blog-post/domain/events/blog-post-updated.domain-event.ts
+++ b/src/features/blog-post/domain/events/blog-post-updated.domain-event.ts
@@ -1,8 +1,5 @@
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 import { AggregateID } from '@libs/ddd/entity.base';
 
 export class BlogPostUpdatedDomainEvent extends DomainEvent {

--- a/src/features/blog-post/domain/events/blog-post-updated.domain-event.ts
+++ b/src/features/blog-post/domain/events/blog-post-updated.domain-event.ts
@@ -1,9 +1,9 @@
-import type { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
+import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
 import {
   DomainEvent,
   type DomainEventProps,
 } from '@libs/ddd/base-domain.event';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export class BlogPostUpdatedDomainEvent extends DomainEvent {
   readonly updatedProps: {

--- a/src/features/blog-post/dtos/request/decorators/is-in-file-urls.decorator.ts
+++ b/src/features/blog-post/dtos/request/decorators/is-in-file-urls.decorator.ts
@@ -1,6 +1,6 @@
 import {
-  type ValidationArguments,
-  type ValidationOptions,
+  ValidationArguments,
+  ValidationOptions,
   registerDecorator,
 } from 'class-validator';
 

--- a/src/features/blog-post/dtos/request/find-blog-posts-from-blog.request-query-dto.ts
+++ b/src/features/blog-post/dtos/request/find-blog-posts-from-blog.request-query-dto.ts
@@ -1,10 +1,10 @@
 import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
-import type { BlogPostModel } from '@features/blog-post/mappers/blog-post.mapper';
+import { BlogPostModel } from '@features/blog-post/mappers/blog-post.mapper';
 import { CursorPaginationRequestQueryDto } from '@libs/api/dtos/request/cursor-pagination.request-query-dto';
 import { ParseQueryByColonAndTransformToObject } from '@libs/api/transformers/parse-query-by-colon-and-transform-to-object.transformer';
 import { transformStringToBoolean } from '@libs/api/transformers/transform-string-to-boolean.transformer';
 import { SortOrder } from '@libs/api/types/api.constant';
-import type { CursorBy, OrderBy } from '@libs/api/types/api.type';
+import { CursorBy, OrderBy } from '@libs/api/types/api.type';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import {

--- a/src/features/blog-post/dtos/request/find-public-blog-posts.request-query-dto.ts
+++ b/src/features/blog-post/dtos/request/find-public-blog-posts.request-query-dto.ts
@@ -1,8 +1,8 @@
-import type { BlogPostModel } from '@features/blog-post/mappers/blog-post.mapper';
+import { BlogPostModel } from '@features/blog-post/mappers/blog-post.mapper';
 import { CursorPaginationRequestQueryDto } from '@libs/api/dtos/request/cursor-pagination.request-query-dto';
 import { ParseQueryByColonAndTransformToObject } from '@libs/api/transformers/parse-query-by-colon-and-transform-to-object.transformer';
 import { SortOrder } from '@libs/api/types/api.constant';
-import type { CursorBy, OrderBy } from '@libs/api/types/api.type';
+import { CursorBy, OrderBy } from '@libs/api/types/api.type';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptional, Length } from 'class-validator';
 

--- a/src/features/blog-post/dtos/response/blog-post.response-dto.ts
+++ b/src/features/blog-post/dtos/response/blog-post.response-dto.ts
@@ -4,7 +4,7 @@ import { HydratedBlogResponseDto } from '@features/blog/dtos/response/hydrated-b
 import { HydratedTagResponseDto } from '@features/tag/dtos/response/hydrated-tag.response-dto';
 import {
   BaseResponseDto,
-  type CreateBaseResponseDtoProps,
+  CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';

--- a/src/features/blog-post/dtos/response/blog-post.response-dto.ts
+++ b/src/features/blog-post/dtos/response/blog-post.response-dto.ts
@@ -1,12 +1,12 @@
 import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
-import type { BlogPostContents } from '@features/blog-post/types/blog-post.type';
+import { BlogPostContents } from '@features/blog-post/types/blog-post.type';
 import { HydratedBlogResponseDto } from '@features/blog/dtos/response/hydrated-blog.response-dto';
 import { HydratedTagResponseDto } from '@features/tag/dtos/response/hydrated-tag.response-dto';
 import {
   BaseResponseDto,
   type CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export interface CreateBlogPostResponseDtoProps

--- a/src/features/blog-post/mappers/blog-post.mapper.ts
+++ b/src/features/blog-post/mappers/blog-post.mapper.ts
@@ -1,20 +1,20 @@
 import {
-  type BlogPostAttachmentMapper,
+  BlogPostAttachmentMapper,
   blogPostAttachmentSchema,
 } from '@features/blog-post/blog-post-attachment/mappers/blog-post-attachment.mapper';
 import {
-  type BlogPostCommentMapper,
+  BlogPostCommentMapper,
   blogPostCommentSchema,
 } from '@features/blog-post/blog-post-comment/mappers/blog-post-comment.mapper';
 import {
-  type BlogPostTagMapper,
+  BlogPostTagMapper,
   blogPostTagSchema,
 } from '@features/blog-post/blog-post-tag/mappers/blog-post-tag.mapper';
 import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
 import { BlogPostProps } from '@features/blog-post/domain/blog-post.entity-interface';
 import {
   BlogPostResponseDto,
-  type CreateBlogPostResponseDtoProps,
+  CreateBlogPostResponseDtoProps,
 } from '@features/blog-post/dtos/response/blog-post.response-dto';
 import { HydratedTagResponseDto } from '@features/tag/dtos/response/hydrated-tag.response-dto';
 import { baseSchema } from '@libs/db/base.schema';

--- a/src/features/blog-post/mappers/blog-post.mapper.ts
+++ b/src/features/blog-post/mappers/blog-post.mapper.ts
@@ -11,15 +11,15 @@ import {
   blogPostTagSchema,
 } from '@features/blog-post/blog-post-tag/mappers/blog-post-tag.mapper';
 import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
-import type { BlogPostProps } from '@features/blog-post/domain/blog-post.entity-interface';
+import { BlogPostProps } from '@features/blog-post/domain/blog-post.entity-interface';
 import {
   BlogPostResponseDto,
   type CreateBlogPostResponseDtoProps,
 } from '@features/blog-post/dtos/response/blog-post.response-dto';
 import { HydratedTagResponseDto } from '@features/tag/dtos/response/hydrated-tag.response-dto';
 import { baseSchema } from '@libs/db/base.schema';
-import type { CreateEntityProps } from '@libs/ddd/entity.base';
-import type { Mapper } from '@libs/ddd/mapper.interface';
+import { CreateEntityProps } from '@libs/ddd/entity.base';
+import { Mapper } from '@libs/ddd/mapper.interface';
 import { isNil } from '@libs/utils/util';
 import { Injectable } from '@nestjs/common';
 import { z } from 'zod';

--- a/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query-handler.ts
+++ b/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query-handler.ts
@@ -1,13 +1,13 @@
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
 import { FindBlogPostsFromBlogQuery } from '@features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { isNil } from '@libs/utils/util';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindBlogPostsFromBlogQuery)

--- a/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query-handler.ts
+++ b/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query-handler.ts
@@ -8,7 +8,7 @@ import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-c
 import { isNil } from '@libs/utils/util';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
-import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindBlogPostsFromBlogQuery)
 export class FindBlogPostsFromBlogQueryHandler

--- a/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query.ts
+++ b/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query.ts
@@ -1,6 +1,6 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { type PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
-import type { IQuery } from '@nestjs/cqrs';
+import { IQuery } from '@nestjs/cqrs';
 
 export class FindBlogPostsFromBlogQuery
   extends PaginatedQueryBase

--- a/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query.ts
+++ b/src/features/blog-post/queries/find-blog-posts-from-blog/find-blog-posts-from-blog.query.ts
@@ -1,5 +1,5 @@
 import { AggregateID } from '@libs/ddd/entity.base';
-import { type PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
+import { PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
 import { IQuery } from '@nestjs/cqrs';
 
 export class FindBlogPostsFromBlogQuery

--- a/src/features/blog-post/queries/find-one-blog-post/find-one-blog-post.query-handler.ts
+++ b/src/features/blog-post/queries/find-one-blog-post/find-one-blog-post.query-handler.ts
@@ -7,7 +7,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { isNil } from '@libs/utils/util';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
-import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindOneBlogPostQuery)
 export class FindOneBlogPostQueryHandler

--- a/src/features/blog-post/queries/find-one-blog-post/find-one-blog-post.query-handler.ts
+++ b/src/features/blog-post/queries/find-one-blog-post/find-one-blog-post.query-handler.ts
@@ -1,12 +1,12 @@
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
 import { FindOneBlogPostQuery } from '@features/blog-post/queries/find-one-blog-post/find-one-blog-post.query';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindOneBlogPostQuery)

--- a/src/features/blog-post/queries/find-one-blog-post/find-one-blog-post.query.ts
+++ b/src/features/blog-post/queries/find-one-blog-post/find-one-blog-post.query.ts
@@ -1,6 +1,6 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { QueryBase } from '@libs/ddd/query.base';
-import type { IQuery } from '@nestjs/cqrs';
+import { IQuery } from '@nestjs/cqrs';
 
 export class FindOneBlogPostQuery extends QueryBase implements IQuery {
   readonly blogPostId: AggregateID;

--- a/src/features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query-handler.ts
+++ b/src/features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query-handler.ts
@@ -1,9 +1,9 @@
 import { BlogPostAttachmentEntity } from '@features/blog-post/blog-post-attachment/domain/blog-post-attachment.entity';
 import { FindPublicBlogPostsQuery } from '@features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query';
 import { UserEntity } from '@features/user/domain/user.entity';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindPublicBlogPostsQuery)

--- a/src/features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query-handler.ts
+++ b/src/features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query-handler.ts
@@ -4,7 +4,7 @@ import { UserEntity } from '@features/user/domain/user.entity';
 import { PrismaService } from '@libs/core/prisma/services/prisma.service';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
-import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindPublicBlogPostsQuery)
 export class FindPublicBlogPostsQueryHandler

--- a/src/features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query.ts
+++ b/src/features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query.ts
@@ -1,5 +1,5 @@
 import { type PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
-import type { IQuery } from '@nestjs/cqrs';
+import { IQuery } from '@nestjs/cqrs';
 
 export class FindPublicBlogPostsQuery
   extends PaginatedQueryBase

--- a/src/features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query.ts
+++ b/src/features/blog-post/queries/find-public-blog-posts/find-public-blog-posts.query.ts
@@ -1,4 +1,4 @@
-import { type PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
+import { PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
 import { IQuery } from '@nestjs/cqrs';
 
 export class FindPublicBlogPostsQuery

--- a/src/features/blog-post/repositories/blog-post.repository-port.ts
+++ b/src/features/blog-post/repositories/blog-post.repository-port.ts
@@ -1,6 +1,6 @@
-import type { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { RepositoryPort } from '@libs/ddd/repository.port';
+import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface BlogPostInclude {
   blogPostAttachments?: boolean;

--- a/src/features/blog-post/repositories/blog-post.repository.ts
+++ b/src/features/blog-post/repositories/blog-post.repository.ts
@@ -1,18 +1,18 @@
-import type { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
-import type {
+import { BlogPostEntity } from '@features/blog-post/domain/blog-post.entity';
+import {
   BlogPostMapper,
   BlogPostWithEntitiesModel,
 } from '@features/blog-post/mappers/blog-post.mapper';
-import type {
+import {
   BlogPostInclude,
   BlogPostRepositoryPort,
 } from '@features/blog-post/repositories/blog-post.repository-port';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
-import type { EventEmitter2 } from '@nestjs/event-emitter';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 @Injectable()
 export class BlogPostRepository implements BlogPostRepositoryPort {

--- a/src/features/blog/application/event-handlers/blog-user-connection-disconnect.domain-event-handler.ts
+++ b/src/features/blog/application/event-handlers/blog-user-connection-disconnect.domain-event-handler.ts
@@ -1,4 +1,4 @@
-import type { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { UserConnectionDisconnectedDomainEvent } from '@features/user/domain/events/user-connection-disconnected.domain-event';
 import { isNil } from '@libs/utils/util';

--- a/src/features/blog/blog.module.ts
+++ b/src/features/blog/blog.module.ts
@@ -8,7 +8,7 @@ import { FindOneBlogByUserIdQueryHandler } from '@features/blog/queries/find-one
 import { BlogRepository } from '@features/blog/repositories/blog.repository';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
 import { UserModule } from '@features/user/user.module';
-import { Module, type Provider } from '@nestjs/common';
+import { Module, Provider } from '@nestjs/common';
 import { NestjsFormDataModule } from 'nestjs-form-data';
 
 const controllers = [BlogController];

--- a/src/features/blog/commands/create-blog/create-blog.command-handler.ts
+++ b/src/features/blog/commands/create-blog/create-blog.command-handler.ts
@@ -1,10 +1,10 @@
 import { CreateBlogCommand } from '@features/blog/commands/create-blog/create-blog.command';
-import type { BlogDomainService } from '@features/blog/domain/domain-services/blog.domain-service';
-import type { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { BlogDomainService } from '@features/blog/domain/domain-services/blog.domain-service';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';

--- a/src/features/blog/commands/create-blog/create-blog.command-handler.ts
+++ b/src/features/blog/commands/create-blog/create-blog.command-handler.ts
@@ -10,7 +10,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(CreateBlogCommand)
 export class CreateBlogCommandHandler

--- a/src/features/blog/commands/create-blog/create-blog.command.ts
+++ b/src/features/blog/commands/create-blog/create-blog.command.ts
@@ -1,7 +1,7 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { FileProps } from '@libs/types/type';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { FileProps } from '@libs/types/type';
+import { ICommand } from '@nestjs/cqrs';
 
 export class CreateBlogCommand extends Command implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/blog/commands/create-blog/create-blog.command.ts
+++ b/src/features/blog/commands/create-blog/create-blog.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { FileProps } from '@libs/types/type';
 import { ICommand } from '@nestjs/cqrs';

--- a/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
+++ b/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
@@ -1,8 +1,8 @@
 import { PatchUpdateBlogCommand } from '@features/blog/commands/patch-update-blog/patch-update-blog.command';
-import type { BlogEntity } from '@features/blog/domain/blog.entity';
-import type { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { BlogEntity } from '@features/blog/domain/blog.entity';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';

--- a/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
+++ b/src/features/blog/commands/patch-update-blog/patch-update-blog.command-handler.ts
@@ -10,7 +10,7 @@ import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-c
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(PatchUpdateBlogCommand)
 export class PatchUpdateBlogCommandHandler

--- a/src/features/blog/commands/patch-update-blog/patch-update-blog.command.ts
+++ b/src/features/blog/commands/patch-update-blog/patch-update-blog.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/blog/commands/patch-update-blog/patch-update-blog.command.ts
+++ b/src/features/blog/commands/patch-update-blog/patch-update-blog.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class PatchUpdateBlogCommand extends Command implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/blog/controllers/blog.controller.ts
+++ b/src/features/blog/controllers/blog.controller.ts
@@ -6,23 +6,23 @@ import {
   BlogAlreadyExistsError,
   CannotCreateBlogWithoutAcceptedConnectionError,
 } from '@features/blog/domain/blog.errors';
-import type { CreateBlogRequestBodyDto } from '@features/blog/dtos/request/create-blog.request-body-dto';
-import type { PatchUpdateBlogRequestBodyDto } from '@features/blog/dtos/request/patch-update-blog.request-body-dto';
+import { CreateBlogRequestBodyDto } from '@features/blog/dtos/request/create-blog.request-body-dto';
+import { PatchUpdateBlogRequestBodyDto } from '@features/blog/dtos/request/patch-update-blog.request-body-dto';
 import { BlogResponseDto } from '@features/blog/dtos/response/blog.response-dto';
 import { FindOneBlogByUserIdQuery } from '@features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query';
-import type { FindOneBlogByUserIdQueryHandler } from '@features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler';
+import { FindOneBlogByUserIdQueryHandler } from '@features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler';
 import { HydratedUserResponseDto } from '@features/user/dtos/response/hydrated-user.response-dto';
 import { ApiInternalServerErrorBuilder } from '@libs/api/decorators/api-internal-server-error-builder.decorator';
 import { User } from '@libs/api/decorators/user.decorator';
 import { IdResponseDto } from '@libs/api/dtos/response/id.response-dto';
 import { NotEmptyObjectPipe } from '@libs/api/pipes/not-empty-object.pipe';
 import { ParsePositiveBigIntPipe } from '@libs/api/pipes/parse-positive-int.pipe';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions/http-conflict.exception';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { SetGuardType } from '@libs/guards/decorators/set-guard-type.decorator';
 import { GuardType } from '@libs/guards/types/guard.constant';
-import type { HandlerReturnType } from '@libs/types/type';
+import { HandlerReturnType } from '@libs/types/type';
 import {
   Body,
   Controller,
@@ -33,7 +33,7 @@ import {
   Patch,
   Post,
 } from '@nestjs/common';
-import type { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { FormDataRequest } from 'nestjs-form-data';
 

--- a/src/features/blog/controllers/blog.swagger.ts
+++ b/src/features/blog/controllers/blog.swagger.ts
@@ -1,4 +1,4 @@
-import type { BlogController } from '@features/blog/controllers/blog.controller';
+import { BlogController } from '@features/blog/controllers/blog.controller';
 import { IdResponseDto } from '@libs/api/dtos/response/id.response-dto';
 import { HttpStatus, applyDecorators } from '@nestjs/common';
 import {
@@ -21,10 +21,7 @@ import { BLOG_ERROR_CODE } from '@libs/exceptions/types/errors/blog/blog-error-c
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { CustomValidationError } from '@libs/types/custom-validation-errors.type';
-import type {
-  ApiOperationOptionsWithSummary,
-  ApiOperator,
-} from '@libs/types/type';
+import { ApiOperationOptionsWithSummary, ApiOperator } from '@libs/types/type';
 
 export const ApiBlog: ApiOperator<keyof BlogController> = {
   Create: (

--- a/src/features/blog/domain/blog.entity-interface.ts
+++ b/src/features/blog/domain/blog.entity-interface.ts
@@ -1,6 +1,6 @@
-import type { HydratedUserEntityProps } from '@features/user/domain/user.entity-interface';
-import type { AggregateID, BaseEntityProps } from '@libs/ddd/entity.base';
-import type { FileProps } from '@libs/types/type';
+import { HydratedUserEntityProps } from '@features/user/domain/user.entity-interface';
+import { AggregateID, BaseEntityProps } from '@libs/ddd/entity.base';
+import { FileProps } from '@libs/types/type';
 
 export interface BlogProps {
   createdBy: AggregateID;

--- a/src/features/blog/domain/blog.entity.ts
+++ b/src/features/blog/domain/blog.entity.ts
@@ -1,6 +1,6 @@
 import { getTsid } from 'tsid-ts';
 
-import type {
+import {
   BlogProps,
   CreateBlogProps,
   HydratedBlogEntityProps,
@@ -8,14 +8,14 @@ import type {
 import { BlogBackgroundImagePathUpdatedDomainEvent } from '@features/blog/domain/events/blog-background-image-updated.domain-event';
 import { BlogCreatedDomainEvent } from '@features/blog/domain/events/blog-created.domain-event';
 import { BlogDeletedDomainEvent } from '@features/blog/domain/events/blog-deleted.domain-event';
-import type { UserEntity } from '@features/user/domain/user.entity';
-import type { HydratedUserEntityProps } from '@features/user/domain/user.entity-interface';
+import { UserEntity } from '@features/user/domain/user.entity';
+import { HydratedUserEntityProps } from '@features/user/domain/user.entity-interface';
 import { AggregateRoot } from '@libs/ddd/aggregate-root.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { Guard } from '@libs/guard';
-import type { FileProps } from '@libs/types/type';
+import { FileProps } from '@libs/types/type';
 import { isNil } from '@libs/utils/util';
 
 export class BlogEntity extends AggregateRoot<BlogProps> {

--- a/src/features/blog/domain/domain-services/blog.domain-service.ts
+++ b/src/features/blog/domain/domain-services/blog.domain-service.ts
@@ -1,12 +1,12 @@
 import { BlogEntity } from '@features/blog/domain/blog.entity';
-import type { CreateBlogProps } from '@features/blog/domain/blog.entity-interface';
+import { CreateBlogProps } from '@features/blog/domain/blog.entity-interface';
 import {
   BlogAlreadyExistsError,
   CannotCreateBlogWithoutAcceptedConnectionError,
 } from '@features/blog/domain/blog.errors';
-import type { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
 import { BLOG_REPOSITORY_DI_TOKEN } from '@features/blog/tokens/di.token';
-import type { UserEntity } from '@features/user/domain/user.entity';
+import { UserEntity } from '@features/user/domain/user.entity';
 import { isNil } from '@libs/utils/util';
 import { Inject, Injectable } from '@nestjs/common';
 

--- a/src/features/blog/domain/events/blog-background-image-updated.domain-event.ts
+++ b/src/features/blog/domain/events/blog-background-image-updated.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { FileProps } from '@libs/types/type';
 

--- a/src/features/blog/domain/events/blog-background-image-updated.domain-event.ts
+++ b/src/features/blog/domain/events/blog-background-image-updated.domain-event.ts
@@ -2,8 +2,8 @@ import {
   DomainEvent,
   type DomainEventProps,
 } from '@libs/ddd/base-domain.event';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { FileProps } from '@libs/types/type';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { FileProps } from '@libs/types/type';
 
 export class BlogBackgroundImagePathUpdatedDomainEvent extends DomainEvent {
   readonly backgroundImageFile:

--- a/src/features/blog/domain/events/blog-created.domain-event.ts
+++ b/src/features/blog/domain/events/blog-created.domain-event.ts
@@ -2,8 +2,8 @@ import {
   DomainEvent,
   type DomainEventProps,
 } from '@libs/ddd/base-domain.event';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { FileProps } from '@libs/types/type';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { FileProps } from '@libs/types/type';
 
 export class BlogCreatedDomainEvent extends DomainEvent {
   readonly backgroundImageFile:

--- a/src/features/blog/domain/events/blog-created.domain-event.ts
+++ b/src/features/blog/domain/events/blog-created.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { FileProps } from '@libs/types/type';
 

--- a/src/features/blog/domain/events/blog-deleted.domain-event.ts
+++ b/src/features/blog/domain/events/blog-deleted.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 
 export class BlogDeletedDomainEvent extends DomainEvent {
   constructor(props: DomainEventProps<BlogDeletedDomainEvent>) {

--- a/src/features/blog/dtos/request/create-blog.request-body-dto.ts
+++ b/src/features/blog/dtos/request/create-blog.request-body-dto.ts
@@ -8,7 +8,7 @@ import {
   HasMimeType,
   IsFile,
   MaxFileSize,
-  type MemoryStoredFile,
+  MemoryStoredFile,
 } from 'nestjs-form-data';
 
 export class CreateBlogRequestBodyDto {

--- a/src/features/blog/dtos/request/patch-update-blog.request-body-dto.ts
+++ b/src/features/blog/dtos/request/patch-update-blog.request-body-dto.ts
@@ -9,7 +9,7 @@ import {
   HasMimeType,
   IsFile,
   MaxFileSize,
-  type MemoryStoredFile,
+  MemoryStoredFile,
 } from 'nestjs-form-data';
 
 export class PatchUpdateBlogRequestBodyDto extends PartialType(

--- a/src/features/blog/dtos/response/blog.response-dto.ts
+++ b/src/features/blog/dtos/response/blog.response-dto.ts
@@ -3,7 +3,7 @@ import {
   BaseResponseDto,
   type CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export interface CreateBlogResponseDtoProps extends CreateBaseResponseDtoProps {

--- a/src/features/blog/dtos/response/blog.response-dto.ts
+++ b/src/features/blog/dtos/response/blog.response-dto.ts
@@ -1,7 +1,7 @@
 import { HydratedUserResponseDto } from '@features/user/dtos/response/hydrated-user.response-dto';
 import {
   BaseResponseDto,
-  type CreateBaseResponseDtoProps,
+  CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';

--- a/src/features/blog/dtos/response/hydrated-blog.response-dto.ts
+++ b/src/features/blog/dtos/response/hydrated-blog.response-dto.ts
@@ -1,7 +1,7 @@
 import { HydratedUserResponseDto } from '@features/user/dtos/response/hydrated-user.response-dto';
 import {
   BaseResponseDto,
-  type CreateBaseResponseDtoProps,
+  CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 

--- a/src/features/blog/mappers/blog.mapper.ts
+++ b/src/features/blog/mappers/blog.mapper.ts
@@ -1,13 +1,13 @@
 import { BlogEntity } from '@features/blog/domain/blog.entity';
-import type { BlogProps } from '@features/blog/domain/blog.entity-interface';
+import { BlogProps } from '@features/blog/domain/blog.entity-interface';
 import {
   BlogResponseDto,
   type CreateBlogResponseDtoProps,
 } from '@features/blog/dtos/response/blog.response-dto';
 import { HydratedUserResponseDto } from '@features/user/dtos/response/hydrated-user.response-dto';
 import { baseSchema } from '@libs/db/base.schema';
-import type { CreateEntityProps } from '@libs/ddd/entity.base';
-import type { Mapper } from '@libs/ddd/mapper.interface';
+import { CreateEntityProps } from '@libs/ddd/entity.base';
+import { Mapper } from '@libs/ddd/mapper.interface';
 import { z } from 'zod';
 
 export const blogSchema = baseSchema.extend({

--- a/src/features/blog/mappers/blog.mapper.ts
+++ b/src/features/blog/mappers/blog.mapper.ts
@@ -2,7 +2,7 @@ import { BlogEntity } from '@features/blog/domain/blog.entity';
 import { BlogProps } from '@features/blog/domain/blog.entity-interface';
 import {
   BlogResponseDto,
-  type CreateBlogResponseDtoProps,
+  CreateBlogResponseDtoProps,
 } from '@features/blog/dtos/response/blog.response-dto';
 import { HydratedUserResponseDto } from '@features/user/dtos/response/hydrated-user.response-dto';
 import { baseSchema } from '@libs/db/base.schema';

--- a/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
+++ b/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
@@ -8,7 +8,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { isNil } from '@libs/utils/util';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
-import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindOneBlogByUserIdQuery)
 export class FindOneBlogByUserIdQueryHandler

--- a/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
+++ b/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query-handler.ts
@@ -2,12 +2,12 @@ import { BlogEntity } from '@features/blog/domain/blog.entity';
 import { FindOneBlogByUserIdQuery } from '@features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query';
 import { UserEntity } from '@features/user/domain/user.entity';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindOneBlogByUserIdQuery)

--- a/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query.ts
+++ b/src/features/blog/queries/find-one-blog-by-user-id/find-one-blog-by-user-id.query.ts
@@ -1,6 +1,6 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { QueryBase } from '@libs/ddd/query.base';
-import type { IQuery } from '@nestjs/cqrs';
+import { IQuery } from '@nestjs/cqrs';
 
 export class FindOneBlogByUserIdQuery extends QueryBase implements IQuery {
   readonly userId: AggregateID;

--- a/src/features/blog/repositories/blog.repository-port.ts
+++ b/src/features/blog/repositories/blog.repository-port.ts
@@ -1,6 +1,6 @@
-import type { BlogEntity } from '@features/blog/domain/blog.entity';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { RepositoryPort } from '@libs/ddd/repository.port';
+import { BlogEntity } from '@features/blog/domain/blog.entity';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface BlogRepositoryPort extends RepositoryPort<BlogEntity> {
   findOneByConnectionId(

--- a/src/features/blog/repositories/blog.repository.ts
+++ b/src/features/blog/repositories/blog.repository.ts
@@ -1,12 +1,12 @@
-import type { BlogEntity } from '@features/blog/domain/blog.entity';
-import type { BlogMapper } from '@features/blog/mappers/blog.mapper';
-import type { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { BlogEntity } from '@features/blog/domain/blog.entity';
+import { BlogMapper } from '@features/blog/mappers/blog.mapper';
+import { BlogRepositoryPort } from '@features/blog/repositories/blog.repository-port';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
-import type { EventEmitter2 } from '@nestjs/event-emitter';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 @Injectable()
 export class BlogRepository implements BlogRepositoryPort {

--- a/src/features/chat-message/application/event-handler/chat-message-chat-room-deleted.domain-event-handler.ts
+++ b/src/features/chat-message/application/event-handler/chat-message-chat-room-deleted.domain-event-handler.ts
@@ -1,4 +1,4 @@
-import type { ChatMessageRepositoryPort } from '@features/chat-message/repositories/chat-message.repository-port';
+import { ChatMessageRepositoryPort } from '@features/chat-message/repositories/chat-message.repository-port';
 import { CHAT_MESSAGE_REPOSITORY_DI_TOKEN } from '@features/chat-message/tokens/di.token';
 import { ChatRoomDeletedDomainEvent } from '@features/chat-room/domain/events/chat-room-deleted.domain-event';
 import { isNil } from '@libs/utils/util';

--- a/src/features/chat-message/chat-message.module.ts
+++ b/src/features/chat-message/chat-message.module.ts
@@ -10,7 +10,7 @@ import { ChatRoomModule } from '@features/chat-room/chat-room.module';
 import { UserModule } from '@features/user/user.module';
 import { AppJwtModule } from '@libs/app-jwt/app-jwt.module';
 import { GuardModule } from '@libs/guards/guard.module';
-import { Module, type Provider } from '@nestjs/common';
+import { Module, Provider } from '@nestjs/common';
 
 const controllers = [ChatMessageController];
 

--- a/src/features/chat-message/commands/create-message/create-chat-message.command-handler.ts
+++ b/src/features/chat-message/commands/create-message/create-chat-message.command-handler.ts
@@ -11,7 +11,7 @@ import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(CreateChatMessageCommand)
 export class CreateChatMessageCommandHandler

--- a/src/features/chat-message/commands/create-message/create-chat-message.command-handler.ts
+++ b/src/features/chat-message/commands/create-message/create-chat-message.command-handler.ts
@@ -1,8 +1,8 @@
 import { CreateChatMessageCommand } from '@features/chat-message/commands/create-message/create-chat-message.command';
 import { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
-import type { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
+import { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
 import { CHAT_ROOM_REPOSITORY_DI_TOKEN } from '@features/chat-room/tokens/di.token';
-import type { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
+import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
 import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';

--- a/src/features/chat-message/commands/create-message/create-chat-message.command.ts
+++ b/src/features/chat-message/commands/create-message/create-chat-message.command.ts
@@ -1,6 +1,6 @@
-import type { CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { CommandProps } from '@libs/ddd/command.base';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class CreateChatMessageCommand implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/chat-message/controllers/chat-message.controller.ts
+++ b/src/features/chat-message/controllers/chat-message.controller.ts
@@ -1,19 +1,19 @@
 import { ApiChatMessage } from '@features/chat-message/controllers/chat-message.swagger';
-import type { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
-import type { FindChatMessagesRequestQueryDto } from '@features/chat-message/dtos/request/find-chat-messages.request-query-dto';
-import type { ChatMessageResponseDto } from '@features/chat-message/dtos/response/chat-message.response-dto';
+import { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
+import { FindChatMessagesRequestQueryDto } from '@features/chat-message/dtos/request/find-chat-messages.request-query-dto';
+import { ChatMessageResponseDto } from '@features/chat-message/dtos/response/chat-message.response-dto';
 import { User } from '@libs/api/decorators/user.decorator';
 import { ParsePositiveBigIntPipe } from '@libs/api/pipes/parse-positive-int.pipe';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { Controller, Get, Param, Query } from '@nestjs/common';
-import type { QueryBus } from '@nestjs/cqrs';
+import { QueryBus } from '@nestjs/cqrs';
 import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { routesV1 } from '@src/configs/app.route';
-import type { ChatMessageMapper } from '@src/features/chat-message/mappers/chat-message.mapper';
+import { ChatMessageMapper } from '@src/features/chat-message/mappers/chat-message.mapper';
 import { FindChatMessagesQuery } from '@src/features/chat-message/queries/find-chat-messages/find-chat-messages.query';
 import { ApiInternalServerErrorBuilder } from '@src/libs/api/decorators/api-internal-server-error-builder.decorator';
 import { SetPagination } from '@src/libs/interceptors/pagination/decorators/pagination-interceptor.decorator';
-import type { Paginated } from '@src/libs/types/type';
+import { Paginated } from '@src/libs/types/type';
 
 @ApiTags('ChatMessage')
 @ApiInternalServerErrorBuilder()

--- a/src/features/chat-message/controllers/chat-message.swagger.ts
+++ b/src/features/chat-message/controllers/chat-message.swagger.ts
@@ -1,4 +1,4 @@
-import type { ChatMessageController } from '@features/chat-message/controllers/chat-message.controller';
+import { ChatMessageController } from '@features/chat-message/controllers/chat-message.controller';
 import { ChatMessageResponseDto } from '@features/chat-message/dtos/response/chat-message.response-dto';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
@@ -8,10 +8,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { CursorPaginationResponseDto } from '@libs/interceptors/pagination/dtos/cursor-pagination-interceptor.response-dto';
 import { OffsetPaginationResponseDto } from '@libs/interceptors/pagination/dtos/offset-pagination-interceptor.response-dto';
 import { CustomValidationError } from '@libs/types/custom-validation-errors.type';
-import type {
-  ApiOperationOptionsWithSummary,
-  ApiOperator,
-} from '@libs/types/type';
+import { ApiOperationOptionsWithSummary, ApiOperator } from '@libs/types/type';
 import { HttpStatus, applyDecorators } from '@nestjs/common';
 import {
   ApiBearerAuth,

--- a/src/features/chat-message/domain/chat-message.entity-interface.ts
+++ b/src/features/chat-message/domain/chat-message.entity-interface.ts
@@ -1,4 +1,4 @@
-import type { AggregateID } from '@src/libs/ddd/entity.base';
+import { AggregateID } from '@src/libs/ddd/entity.base';
 
 export interface ChatMessageProps {
   roomId: AggregateID;

--- a/src/features/chat-message/domain/chat-message.entity.ts
+++ b/src/features/chat-message/domain/chat-message.entity.ts
@@ -1,4 +1,4 @@
-import type {
+import {
   ChatMessageProps,
   CreateChatMessageProps,
 } from '@features/chat-message/domain/chat-message.entity-interface';

--- a/src/features/chat-message/dtos/request/find-chat-messages.request-query-dto.ts
+++ b/src/features/chat-message/dtos/request/find-chat-messages.request-query-dto.ts
@@ -1,8 +1,8 @@
-import type { ChatMessageModel } from '@src/features/chat-message/mappers/chat-message.mapper';
+import { ChatMessageModel } from '@src/features/chat-message/mappers/chat-message.mapper';
 import { CursorPaginationRequestQueryDto } from '@src/libs/api/dtos/request/cursor-pagination.request-query-dto';
 import { ParseQueryByColonAndTransformToObject } from '@src/libs/api/transformers/parse-query-by-colon-and-transform-to-object.transformer';
 import { SortOrder } from '@src/libs/api/types/api.constant';
-import type { CursorBy, OrderBy } from '@src/libs/api/types/api.type';
+import { CursorBy, OrderBy } from '@src/libs/api/types/api.type';
 import { IsOptional } from 'class-validator';
 
 type ChatMessagesModelForPaginated = Pick<

--- a/src/features/chat-message/dtos/response/chat-message.response-dto.ts
+++ b/src/features/chat-message/dtos/response/chat-message.response-dto.ts
@@ -2,7 +2,7 @@ import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty } from '@nestjs/swagger';
 import {
   BaseResponseDto,
-  type CreateBaseResponseDtoProps,
+  CreateBaseResponseDtoProps,
 } from '@src/libs/api/dtos/response/base.response-dto';
 
 export interface CreateChatMessageResponseDtoProps

--- a/src/features/chat-message/dtos/response/chat-message.response-dto.ts
+++ b/src/features/chat-message/dtos/response/chat-message.response-dto.ts
@@ -1,4 +1,4 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty } from '@nestjs/swagger';
 import {
   BaseResponseDto,

--- a/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
+++ b/src/features/chat-message/dtos/socket/create-chat-message.dto.ts
@@ -1,6 +1,6 @@
 import { IsBigIntString } from '@libs/api/decorators/is-big-int.decorator';
 import { IsNullable } from '@libs/api/decorators/is-nullable.decorator';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsUrl, Length } from 'class-validator';
 

--- a/src/features/chat-message/dtos/socket/enter-chat.dto.ts
+++ b/src/features/chat-message/dtos/socket/enter-chat.dto.ts
@@ -1,5 +1,5 @@
 import { IsPositiveBigInt } from '@libs/api/decorators/is-positive-bigint.decorator';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class EnterChatDto {

--- a/src/features/chat-message/gateways/chat-message.gateway.ts
+++ b/src/features/chat-message/gateways/chat-message.gateway.ts
@@ -15,17 +15,17 @@ import { CustomValidationPipe } from '@libs/pipes/custom-validation.pipe';
 import { isNil } from '@libs/utils/util';
 import {
   Inject,
-  type Logger,
+  Logger,
   UseFilters,
   UsePipes,
-  type ValidationPipeOptions,
+  ValidationPipeOptions,
 } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
 import {
   ConnectedSocket,
   MessageBody,
-  type OnGatewayConnection,
-  type OnGatewayDisconnect,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
   SubscribeMessage,
   WebSocketGateway,
   WebSocketServer,

--- a/src/features/chat-message/gateways/chat-message.gateway.ts
+++ b/src/features/chat-message/gateways/chat-message.gateway.ts
@@ -1,12 +1,12 @@
 import { CreateChatMessageCommand } from '@features/chat-message/commands/create-message/create-chat-message.command';
-import type { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
-import type { CreateChatMessageDto } from '@features/chat-message/dtos/socket/create-chat-message.dto';
-import type { EnterChatDto } from '@features/chat-message/dtos/socket/enter-chat.dto';
-import type { SocketWithUserDto } from '@features/chat-message/dtos/socket/socket-with-user.dto';
-import type { ChatMessageMapper } from '@features/chat-message/mappers/chat-message.mapper';
-import type { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
+import { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
+import { CreateChatMessageDto } from '@features/chat-message/dtos/socket/create-chat-message.dto';
+import { EnterChatDto } from '@features/chat-message/dtos/socket/enter-chat.dto';
+import { SocketWithUserDto } from '@features/chat-message/dtos/socket/socket-with-user.dto';
+import { ChatMessageMapper } from '@features/chat-message/mappers/chat-message.mapper';
+import { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
 import { CHAT_ROOM_REPOSITORY_DI_TOKEN } from '@features/chat-room/tokens/di.token';
-import type { AppJwtServicePort } from '@libs/app-jwt/services/app-jwt.service-port';
+import { AppJwtServicePort } from '@libs/app-jwt/services/app-jwt.service-port';
 import { APP_JWT_SERVICE_DI_TOKEN } from '@libs/app-jwt/tokens/app-jwt.di-token';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { SocketCatchHttpExceptionFilter } from '@libs/exceptions/socket/filters/socket-catch-http.exception-filter';
@@ -20,7 +20,7 @@ import {
   UsePipes,
   type ValidationPipeOptions,
 } from '@nestjs/common';
-import type { CommandBus } from '@nestjs/cqrs';
+import { CommandBus } from '@nestjs/cqrs';
 import {
   ConnectedSocket,
   MessageBody,
@@ -31,9 +31,9 @@ import {
   WebSocketServer,
   WsException,
 } from '@nestjs/websockets';
-import type { ValidationError } from 'class-validator';
+import { ValidationError } from 'class-validator';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
-import type { Server } from 'socket.io';
+import { Server } from 'socket.io';
 
 const options: Omit<ValidationPipeOptions, 'exceptionFactory'> = {
   transform: true,

--- a/src/features/chat-message/mappers/chat-message.mapper.ts
+++ b/src/features/chat-message/mappers/chat-message.mapper.ts
@@ -1,11 +1,11 @@
 import { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
-import type { ChatMessageProps } from '@features/chat-message/domain/chat-message.entity-interface';
+import { ChatMessageProps } from '@features/chat-message/domain/chat-message.entity-interface';
 import { ChatMessageResponseDto } from '@features/chat-message/dtos/response/chat-message.response-dto';
 import { Injectable } from '@nestjs/common';
 
 import { baseSchema } from '@src/libs/db/base.schema';
-import type { CreateEntityProps } from '@src/libs/ddd/entity.base';
-import type { Mapper } from '@src/libs/ddd/mapper.interface';
+import { CreateEntityProps } from '@src/libs/ddd/entity.base';
+import { Mapper } from '@src/libs/ddd/mapper.interface';
 import { z } from 'zod';
 
 export const chatMessageSchema = baseSchema.extend({

--- a/src/features/chat-message/queries/find-chat-messages/find-chat-messages.query-handler.ts
+++ b/src/features/chat-message/queries/find-chat-messages/find-chat-messages.query-handler.ts
@@ -11,7 +11,7 @@ import { isNil } from '@libs/utils/util';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Inject } from '@nestjs/common';
-import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { ChatMessageMapper } from '@src/features/chat-message/mappers/chat-message.mapper';
 import { FindChatMessagesQuery } from '@src/features/chat-message/queries/find-chat-messages/find-chat-messages.query';
 import { PrismaService } from '@src/libs/core/prisma/services/prisma.service';

--- a/src/features/chat-message/queries/find-chat-messages/find-chat-messages.query-handler.ts
+++ b/src/features/chat-message/queries/find-chat-messages/find-chat-messages.query-handler.ts
@@ -1,21 +1,21 @@
-import type { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
-import type { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
+import { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
+import { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
 import { CHAT_ROOM_REPOSITORY_DI_TOKEN } from '@features/chat-room/tokens/di.token';
-import type { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
+import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
 import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Inject } from '@nestjs/common';
 import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
-import type { ChatMessageMapper } from '@src/features/chat-message/mappers/chat-message.mapper';
+import { ChatMessageMapper } from '@src/features/chat-message/mappers/chat-message.mapper';
 import { FindChatMessagesQuery } from '@src/features/chat-message/queries/find-chat-messages/find-chat-messages.query';
-import type { PrismaService } from '@src/libs/core/prisma/services/prisma.service';
-import type { Paginated } from '@src/libs/types/type';
+import { PrismaService } from '@src/libs/core/prisma/services/prisma.service';
+import { Paginated } from '@src/libs/types/type';
 
 @QueryHandler(FindChatMessagesQuery)
 export class FindChatMessagesQueryHandler

--- a/src/features/chat-message/queries/find-chat-messages/find-chat-messages.query.ts
+++ b/src/features/chat-message/queries/find-chat-messages/find-chat-messages.query.ts
@@ -1,5 +1,5 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { IQuery } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { IQuery } from '@nestjs/cqrs';
 import {
   type PaginatedParams,
   PaginatedQueryBase,

--- a/src/features/chat-message/queries/find-chat-messages/find-chat-messages.query.ts
+++ b/src/features/chat-message/queries/find-chat-messages/find-chat-messages.query.ts
@@ -1,9 +1,6 @@
 import { AggregateID } from '@libs/ddd/entity.base';
 import { IQuery } from '@nestjs/cqrs';
-import {
-  type PaginatedParams,
-  PaginatedQueryBase,
-} from '@src/libs/ddd/query.base';
+import { PaginatedParams, PaginatedQueryBase } from '@src/libs/ddd/query.base';
 
 export class FindChatMessagesQuery
   extends PaginatedQueryBase

--- a/src/features/chat-message/repositories/chat-message.repository-port.ts
+++ b/src/features/chat-message/repositories/chat-message.repository-port.ts
@@ -1,6 +1,6 @@
-import type { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { RepositoryPort } from '@libs/ddd/repository.port';
+import { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface ChatMessageRepositoryPort
   extends RepositoryPort<ChatMessageEntity> {

--- a/src/features/chat-message/repositories/chat-message.repository.ts
+++ b/src/features/chat-message/repositories/chat-message.repository.ts
@@ -1,13 +1,13 @@
-import type { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
-import type {
+import { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
+import {
   ChatMessageMapper,
   ChatMessageModel,
 } from '@features/chat-message/mappers/chat-message.mapper';
-import type { ChatMessageRepositoryPort } from '@features/chat-message/repositories/chat-message.repository-port';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { ChatMessageRepositoryPort } from '@features/chat-message/repositories/chat-message.repository-port';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()

--- a/src/features/chat-room/application/event-handlers/chat-room-user-connection-disconnect.domain-event-handler.ts
+++ b/src/features/chat-room/application/event-handlers/chat-room-user-connection-disconnect.domain-event-handler.ts
@@ -1,4 +1,4 @@
-import type { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
+import { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
 import { CHAT_ROOM_REPOSITORY_DI_TOKEN } from '@features/chat-room/tokens/di.token';
 import { UserConnectionDisconnectedDomainEvent } from '@features/user/domain/events/user-connection-disconnected.domain-event';
 import { isNil } from '@libs/utils/util';

--- a/src/features/chat-room/chat-room.module.ts
+++ b/src/features/chat-room/chat-room.module.ts
@@ -7,7 +7,7 @@ import { FindOneChatRoomByUserIdQueryHandler } from '@features/chat-room/queries
 import { ChatRoomRepository } from '@features/chat-room/repositories/chat-room.repository';
 import { CHAT_ROOM_REPOSITORY_DI_TOKEN } from '@features/chat-room/tokens/di.token';
 import { UserModule } from '@features/user/user.module';
-import { Module, type Provider } from '@nestjs/common';
+import { Module, Provider } from '@nestjs/common';
 
 const controllers = [ChatRoomController];
 

--- a/src/features/chat-room/commands/create-chat-room/create-chat-room.command-handler.ts
+++ b/src/features/chat-room/commands/create-chat-room/create-chat-room.command-handler.ts
@@ -1,10 +1,10 @@
 import { CreateChatRoomCommand } from '@features/chat-room/commands/create-chat-room/create-chat-room.command';
 import { ChatRoomEntity } from '@features/chat-room/domain/chat-room.entity';
-import type { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
+import { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
 import { CHAT_ROOM_REPOSITORY_DI_TOKEN } from '@features/chat-room/tokens/di.token';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions/http-conflict.exception';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';

--- a/src/features/chat-room/commands/create-chat-room/create-chat-room.command-handler.ts
+++ b/src/features/chat-room/commands/create-chat-room/create-chat-room.command-handler.ts
@@ -13,7 +13,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(CreateChatRoomCommand)
 export class CreateChatRoomCommandHandler

--- a/src/features/chat-room/commands/create-chat-room/create-chat-room.command.ts
+++ b/src/features/chat-room/commands/create-chat-room/create-chat-room.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class CreateChatRoomCommand extends Command implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/chat-room/commands/create-chat-room/create-chat-room.command.ts
+++ b/src/features/chat-room/commands/create-chat-room/create-chat-room.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/chat-room/controllers/chat-room.controller.ts
+++ b/src/features/chat-room/controllers/chat-room.controller.ts
@@ -3,14 +3,14 @@ import { CreateChatRoomCommand } from '@features/chat-room/commands/create-chat-
 import { ApiChatRoom } from '@features/chat-room/controllers/chat-room.swagger';
 import { ChatRoomResponseDto } from '@features/chat-room/dtos/response/chat-room.response-dto';
 import { FindOneChatRoomByUserIdQuery } from '@features/chat-room/queries/find-one-chat-room-by-user-id/find-one-chat-room-by-user-id.query';
-import type { FindOneChatRoomByUserIdQueryHandler } from '@features/chat-room/queries/find-one-chat-room-by-user-id/find-one-chat-room-by-user-id.query-handler';
+import { FindOneChatRoomByUserIdQueryHandler } from '@features/chat-room/queries/find-one-chat-room-by-user-id/find-one-chat-room-by-user-id.query-handler';
 import { ApiInternalServerErrorBuilder } from '@libs/api/decorators/api-internal-server-error-builder.decorator';
 import { User } from '@libs/api/decorators/user.decorator';
 import { IdResponseDto } from '@libs/api/dtos/response/id.response-dto';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { HandlerReturnType } from '@libs/types/type';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { HandlerReturnType } from '@libs/types/type';
 import { Controller, Get, Post } from '@nestjs/common';
-import type { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('ChatRoom')

--- a/src/features/chat-room/controllers/chat-room.swagger.ts
+++ b/src/features/chat-room/controllers/chat-room.swagger.ts
@@ -1,4 +1,4 @@
-import type { ChatRoomController } from '@features/chat-room/controllers/chat-room.controller';
+import { ChatRoomController } from '@features/chat-room/controllers/chat-room.controller';
 import { IdResponseDto } from '@libs/api/dtos/response/id.response-dto';
 import { HttpStatus, applyDecorators } from '@nestjs/common';
 import {
@@ -18,10 +18,7 @@ import { CHAT_ROOM_ERROR_CODE } from '@libs/exceptions/types/errors/chat-room/ch
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { CustomValidationError } from '@libs/types/custom-validation-errors.type';
-import type {
-  ApiOperationOptionsWithSummary,
-  ApiOperator,
-} from '@libs/types/type';
+import { ApiOperationOptionsWithSummary, ApiOperator } from '@libs/types/type';
 
 export const ApiChatRoom: ApiOperator<keyof ChatRoomController> = {
   Create: (

--- a/src/features/chat-room/domain/chat-room.entity-interface.ts
+++ b/src/features/chat-room/domain/chat-room.entity-interface.ts
@@ -1,4 +1,4 @@
-import type { AggregateID, BaseEntityProps } from '@libs/ddd/entity.base';
+import { AggregateID, BaseEntityProps } from '@libs/ddd/entity.base';
 
 export interface ChatRoomProps {
   createdBy: AggregateID;

--- a/src/features/chat-room/domain/chat-room.entity.ts
+++ b/src/features/chat-room/domain/chat-room.entity.ts
@@ -1,6 +1,6 @@
 import { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
-import type { CreateChatMessageProps } from '@features/chat-message/domain/chat-message.entity-interface';
-import type {
+import { CreateChatMessageProps } from '@features/chat-message/domain/chat-message.entity-interface';
+import {
   ChatRoomProps,
   CreateChatRoomProps,
   HydratedChatRoomEntityProps,

--- a/src/features/chat-room/domain/events/chat-room-deleted.domain-event.ts
+++ b/src/features/chat-room/domain/events/chat-room-deleted.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 
 export class ChatRoomDeletedDomainEvent extends DomainEvent {
   constructor(props: DomainEventProps<ChatRoomDeletedDomainEvent>) {

--- a/src/features/chat-room/dtos/response/chat-room.response-dto.ts
+++ b/src/features/chat-room/dtos/response/chat-room.response-dto.ts
@@ -1,6 +1,6 @@
 import {
   BaseResponseDto,
-  type CreateBaseResponseDtoProps,
+  CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty } from '@nestjs/swagger';

--- a/src/features/chat-room/dtos/response/chat-room.response-dto.ts
+++ b/src/features/chat-room/dtos/response/chat-room.response-dto.ts
@@ -2,7 +2,7 @@ import {
   BaseResponseDto,
   type CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty } from '@nestjs/swagger';
 
 export interface CreateChatRoomResponseDtoProps

--- a/src/features/chat-room/dtos/response/hydrated-chat-room.response-dto.ts
+++ b/src/features/chat-room/dtos/response/hydrated-chat-room.response-dto.ts
@@ -1,6 +1,6 @@
 import {
   BaseResponseDto,
-  type CreateBaseResponseDtoProps,
+  CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
 
 export interface CreateHydratedChatRoomProps

--- a/src/features/chat-room/mappers/chat-room.mapper.ts
+++ b/src/features/chat-room/mappers/chat-room.mapper.ts
@@ -1,9 +1,9 @@
 import { ChatRoomEntity } from '@features/chat-room/domain/chat-room.entity';
-import type { ChatRoomProps } from '@features/chat-room/domain/chat-room.entity-interface';
+import { ChatRoomProps } from '@features/chat-room/domain/chat-room.entity-interface';
 import { ChatRoomResponseDto } from '@features/chat-room/dtos/response/chat-room.response-dto';
 import { baseSchema } from '@libs/db/base.schema';
-import type { CreateEntityProps } from '@libs/ddd/entity.base';
-import type { Mapper } from '@libs/ddd/mapper.interface';
+import { CreateEntityProps } from '@libs/ddd/entity.base';
+import { Mapper } from '@libs/ddd/mapper.interface';
 import { Injectable } from '@nestjs/common';
 import { z } from 'zod';
 

--- a/src/features/chat-room/queries/find-one-chat-room-by-user-id/find-one-chat-room-by-user-id.query-handler.ts
+++ b/src/features/chat-room/queries/find-one-chat-room-by-user-id/find-one-chat-room-by-user-id.query-handler.ts
@@ -6,7 +6,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { isNil } from '@libs/utils/util';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
-import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindOneChatRoomByUserIdQuery)
 export class FindOneChatRoomByUserIdQueryHandler

--- a/src/features/chat-room/queries/find-one-chat-room-by-user-id/find-one-chat-room-by-user-id.query-handler.ts
+++ b/src/features/chat-room/queries/find-one-chat-room-by-user-id/find-one-chat-room-by-user-id.query-handler.ts
@@ -1,11 +1,11 @@
 import { FindOneChatRoomByUserIdQuery } from '@features/chat-room/queries/find-one-chat-room-by-user-id/find-one-chat-room-by-user-id.query';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindOneChatRoomByUserIdQuery)

--- a/src/features/chat-room/queries/find-one-chat-room-by-user-id/find-one-chat-room-by-user-id.query.ts
+++ b/src/features/chat-room/queries/find-one-chat-room-by-user-id/find-one-chat-room-by-user-id.query.ts
@@ -1,6 +1,6 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { QueryBase } from '@libs/ddd/query.base';
-import type { IQuery } from '@nestjs/cqrs';
+import { IQuery } from '@nestjs/cqrs';
 
 export class FindOneChatRoomByUserIdQuery extends QueryBase implements IQuery {
   readonly userId: AggregateID;

--- a/src/features/chat-room/repositories/chat-room.repository-port.ts
+++ b/src/features/chat-room/repositories/chat-room.repository-port.ts
@@ -1,7 +1,7 @@
-import type { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
-import type { ChatRoomEntity } from '@features/chat-room/domain/chat-room.entity';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { RepositoryPort } from '@libs/ddd/repository.port';
+import { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
+import { ChatRoomEntity } from '@features/chat-room/domain/chat-room.entity';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface ChatRoomRepositoryPort extends RepositoryPort<ChatRoomEntity> {
   findOneByConnectionId(

--- a/src/features/chat-room/repositories/chat-room.repository.ts
+++ b/src/features/chat-room/repositories/chat-room.repository.ts
@@ -1,14 +1,14 @@
-import type { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
-import type { ChatMessageMapper } from '@features/chat-message/mappers/chat-message.mapper';
-import type { ChatRoomEntity } from '@features/chat-room/domain/chat-room.entity';
-import type { ChatRoomMapper } from '@features/chat-room/mappers/chat-room.mapper';
-import type { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { ChatMessageEntity } from '@features/chat-message/domain/chat-message.entity';
+import { ChatMessageMapper } from '@features/chat-message/mappers/chat-message.mapper';
+import { ChatRoomEntity } from '@features/chat-room/domain/chat-room.entity';
+import { ChatRoomMapper } from '@features/chat-room/mappers/chat-room.mapper';
+import { ChatRoomRepositoryPort } from '@features/chat-room/repositories/chat-room.repository-port';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
-import type { EventEmitter2 } from '@nestjs/event-emitter';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 @Injectable()
 export class ChatRoomRepository implements ChatRoomRepositoryPort {

--- a/src/features/tag/commands/create-new-tags/create-new-tags.command-handler.ts
+++ b/src/features/tag/commands/create-new-tags/create-new-tags.command-handler.ts
@@ -4,7 +4,7 @@ import { TagRepositoryPort } from '@features/tag/repositories/tag.repository-por
 import { TAG_REPOSITORY_DI_TOKEN } from '@features/tag/tokens/di.token';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(CreateNewTagsCommand)
 export class CreateNewTagsCommandHandler

--- a/src/features/tag/commands/create-new-tags/create-new-tags.command-handler.ts
+++ b/src/features/tag/commands/create-new-tags/create-new-tags.command-handler.ts
@@ -1,8 +1,8 @@
 import { CreateNewTagsCommand } from '@features/tag/commands/create-new-tags/create-new-tags.command';
 import { TagEntity } from '@features/tag/domain/tag.entity';
-import type { TagRepositoryPort } from '@features/tag/repositories/tag.repository-port';
+import { TagRepositoryPort } from '@features/tag/repositories/tag.repository-port';
 import { TAG_REPOSITORY_DI_TOKEN } from '@features/tag/tokens/di.token';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { Inject } from '@nestjs/common';
 import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
 

--- a/src/features/tag/commands/create-new-tags/create-new-tags.command.ts
+++ b/src/features/tag/commands/create-new-tags/create-new-tags.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/tag/commands/create-new-tags/create-new-tags.command.ts
+++ b/src/features/tag/commands/create-new-tags/create-new-tags.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class CreateNewTagsCommand extends Command implements ICommand {
   readonly tagNames: string[];

--- a/src/features/tag/domain/tag.entity-interface.ts
+++ b/src/features/tag/domain/tag.entity-interface.ts
@@ -1,4 +1,4 @@
-import type { AggregateID, BaseEntityProps } from '@libs/ddd/entity.base';
+import { AggregateID, BaseEntityProps } from '@libs/ddd/entity.base';
 
 export interface TagProps {
   name: string;

--- a/src/features/tag/domain/tag.entity.ts
+++ b/src/features/tag/domain/tag.entity.ts
@@ -4,7 +4,7 @@ import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { Guard } from '@libs/guard';
 
-import type {
+import {
   CreateTagProps,
   HydratedTagEntityProps,
   TagProps,

--- a/src/features/tag/dtos/response/hydrated-tag.response-dto.ts
+++ b/src/features/tag/dtos/response/hydrated-tag.response-dto.ts
@@ -1,6 +1,6 @@
 import {
   BaseResponseDto,
-  type CreateBaseResponseDtoProps,
+  CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
 import { ApiProperty } from '@nestjs/swagger';
 

--- a/src/features/tag/mappers/tag.mapper.ts
+++ b/src/features/tag/mappers/tag.mapper.ts
@@ -1,8 +1,8 @@
 import { TagEntity } from '@features/tag/domain/tag.entity';
-import type { TagProps } from '@features/tag/domain/tag.entity-interface';
+import { TagProps } from '@features/tag/domain/tag.entity-interface';
 import { baseSchema } from '@libs/db/base.schema';
-import type { CreateEntityProps } from '@libs/ddd/entity.base';
-import type { Mapper } from '@libs/ddd/mapper.interface';
+import { CreateEntityProps } from '@libs/ddd/entity.base';
+import { Mapper } from '@libs/ddd/mapper.interface';
 import { z } from 'zod';
 
 export const tagSchema = baseSchema.extend({

--- a/src/features/tag/repositories/tag.repository-port.ts
+++ b/src/features/tag/repositories/tag.repository-port.ts
@@ -1,5 +1,5 @@
-import type { TagEntity } from '@features/tag/domain/tag.entity';
-import type { RepositoryPort } from '@libs/ddd/repository.port';
+import { TagEntity } from '@features/tag/domain/tag.entity';
+import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface TagRepositoryPort extends RepositoryPort<TagEntity> {
   findByNames(names: string[]): Promise<TagEntity[]>;

--- a/src/features/tag/repositories/tag.repository.ts
+++ b/src/features/tag/repositories/tag.repository.ts
@@ -1,12 +1,12 @@
-import type { TagEntity } from '@features/tag/domain/tag.entity';
-import type { TagMapper } from '@features/tag/mappers/tag.mapper';
-import type { TagRepositoryPort } from '@features/tag/repositories/tag.repository-port';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { TagEntity } from '@features/tag/domain/tag.entity';
+import { TagMapper } from '@features/tag/mappers/tag.mapper';
+import { TagRepositoryPort } from '@features/tag/repositories/tag.repository-port';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
-import type { EventEmitter2 } from '@nestjs/event-emitter';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 @Injectable()
 export class TagRepository implements TagRepositoryPort {

--- a/src/features/tag/tag.module.ts
+++ b/src/features/tag/tag.module.ts
@@ -2,7 +2,7 @@ import { CreateNewTagsCommandHandler } from '@features/tag/commands/create-new-t
 import { TagMapper } from '@features/tag/mappers/tag.mapper';
 import { TagRepository } from '@features/tag/repositories/tag.repository';
 import { TAG_REPOSITORY_DI_TOKEN } from '@features/tag/tokens/di.token';
-import { Module, type Provider } from '@nestjs/common';
+import { Module, Provider } from '@nestjs/common';
 
 const mappers: Provider[] = [TagMapper];
 

--- a/src/features/user/application/event-handlers/create-user-email-verify-token.domain-event-handler.ts
+++ b/src/features/user/application/event-handlers/create-user-email-verify-token.domain-event-handler.ts
@@ -1,10 +1,10 @@
 import { UserCreatedDomainEvent } from '@features/user/domain/events/user-created.event';
 import { UserVerifyTokenEntity } from '@features/user/domain/user-verify-token/user-verify-token.entity';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { UserVerifyTokenType } from '@features/user/types/user.constant';
 import { EMAIL_SERVICE_DI_TOKEN } from '@libs/email/constants/email-service.di-token';
-import type { EmailServicePort } from '@libs/email/services/email.service-port';
+import { EmailServicePort } from '@libs/email/services/email.service-port';
 import { Propagation, Transactional } from '@nestjs-cls/transactional';
 import { Inject, Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';

--- a/src/features/user/commands/create-user/create-user.command-handler.ts
+++ b/src/features/user/commands/create-user/create-user.command-handler.ts
@@ -11,7 +11,7 @@ import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions
 import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-code.constant';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import bcrypt from 'bcrypt';
 
 @CommandHandler(CreateUserCommand)

--- a/src/features/user/commands/create-user/create-user.command-handler.ts
+++ b/src/features/user/commands/create-user/create-user.command-handler.ts
@@ -1,12 +1,12 @@
 import { CreateUserCommand } from '@features/user/commands/create-user/create-user.command';
 import { UserEntity } from '@features/user/domain/user.entity';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { Key } from '@libs/core/app-config/types/app-config.type';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions/http-conflict.exception';
 import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-code.constant';
 import { Transactional } from '@nestjs-cls/transactional';

--- a/src/features/user/commands/create-user/create-user.command.ts
+++ b/src/features/user/commands/create-user/create-user.command.ts
@@ -2,7 +2,7 @@ import {
   UserLoginTypeUnion,
   UserMbtiUnion,
 } from '@features/user/types/user.type';
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { ICommand } from '@nestjs/cqrs';
 
 export class CreateUserCommand extends Command implements ICommand {

--- a/src/features/user/commands/create-user/create-user.command.ts
+++ b/src/features/user/commands/create-user/create-user.command.ts
@@ -1,9 +1,9 @@
-import type {
+import {
   UserLoginTypeUnion,
   UserMbtiUnion,
 } from '@features/user/types/user.type';
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { ICommand } from '@nestjs/cqrs';
 
 export class CreateUserCommand extends Command implements ICommand {
   readonly nickname: string;

--- a/src/features/user/commands/delete-user/delete-user.command-handler.ts
+++ b/src/features/user/commands/delete-user/delete-user.command-handler.ts
@@ -7,7 +7,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(DeleteUserCommand)
 export class DeleteUserCommandHandler

--- a/src/features/user/commands/delete-user/delete-user.command-handler.ts
+++ b/src/features/user/commands/delete-user/delete-user.command-handler.ts
@@ -1,5 +1,5 @@
 import { DeleteUserCommand } from '@features/user/commands/delete-user/delete-user.command';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';

--- a/src/features/user/commands/delete-user/delete-user.command.ts
+++ b/src/features/user/commands/delete-user/delete-user.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class DeleteUserCommand extends Command implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/user/commands/delete-user/delete-user.command.ts
+++ b/src/features/user/commands/delete-user/delete-user.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
+++ b/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
@@ -7,7 +7,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(PatchUpdateUserCommand)
 export class PatchUpdateUserCommandHandler

--- a/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
+++ b/src/features/user/commands/patch-update-user/patch-update-user.command-handler.ts
@@ -1,6 +1,6 @@
 import { PatchUpdateUserCommand } from '@features/user/commands/patch-update-user/patch-update-user.command';
-import type { UserEntity } from '@features/user/domain/user.entity';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserEntity } from '@features/user/domain/user.entity';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';

--- a/src/features/user/commands/patch-update-user/patch-update-user.command.ts
+++ b/src/features/user/commands/patch-update-user/patch-update-user.command.ts
@@ -1,5 +1,5 @@
 import { UserMbtiUnion } from '@features/user/types/user.type';
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/user/commands/patch-update-user/patch-update-user.command.ts
+++ b/src/features/user/commands/patch-update-user/patch-update-user.command.ts
@@ -1,7 +1,7 @@
-import type { UserMbtiUnion } from '@features/user/types/user.type';
+import { UserMbtiUnion } from '@features/user/types/user.type';
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class PatchUpdateUserCommand extends Command implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/user/commands/send-password-change-verification-email/send-password-change-verification-email.command-handler.ts
+++ b/src/features/user/commands/send-password-change-verification-email/send-password-change-verification-email.command-handler.ts
@@ -12,7 +12,7 @@ import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(SendPasswordChangeVerificationEmailCommand)
 export class SendPasswordChangeVerificationEmailCommandHandler

--- a/src/features/user/commands/send-password-change-verification-email/send-password-change-verification-email.command-handler.ts
+++ b/src/features/user/commands/send-password-change-verification-email/send-password-change-verification-email.command-handler.ts
@@ -1,13 +1,13 @@
 import { SendPasswordChangeVerificationEmailCommand } from '@features/user/commands/send-password-change-verification-email/send-password-change-verification-email.command';
 import { UserVerifyTokenEntity } from '@features/user/domain/user-verify-token/user-verify-token.entity';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import {
   UserLoginType,
   UserVerifyTokenType,
 } from '@features/user/types/user.constant';
 import { EMAIL_SERVICE_DI_TOKEN } from '@libs/email/constants/email-service.di-token';
-import type { EmailServicePort } from '@libs/email/services/email.service-port';
+import { EmailServicePort } from '@libs/email/services/email.service-port';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';

--- a/src/features/user/commands/send-password-change-verification-email/send-password-change-verification-email.command.ts
+++ b/src/features/user/commands/send-password-change-verification-email/send-password-change-verification-email.command.ts
@@ -1,5 +1,5 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { ICommand } from '@nestjs/cqrs';
 
 export class SendPasswordChangeVerificationEmailCommand
   extends Command

--- a/src/features/user/commands/send-password-change-verification-email/send-password-change-verification-email.command.ts
+++ b/src/features/user/commands/send-password-change-verification-email/send-password-change-verification-email.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { ICommand } from '@nestjs/cqrs';
 
 export class SendPasswordChangeVerificationEmailCommand

--- a/src/features/user/commands/send-verification-email/send-verification-email.command-handler.ts
+++ b/src/features/user/commands/send-verification-email/send-verification-email.command-handler.ts
@@ -12,7 +12,7 @@ import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-c
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(SendVerificationEmailCommand)
 export class SendVerificationEmailCommandHandler

--- a/src/features/user/commands/send-verification-email/send-verification-email.command-handler.ts
+++ b/src/features/user/commands/send-verification-email/send-verification-email.command-handler.ts
@@ -1,9 +1,9 @@
 import { SendVerificationEmailCommand } from '@features/user/commands/send-verification-email/send-verification-email.command';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { UserVerifyTokenType } from '@features/user/types/user.constant';
 import { EMAIL_SERVICE_DI_TOKEN } from '@libs/email/constants/email-service.di-token';
-import type { EmailServicePort } from '@libs/email/services/email.service-port';
+import { EmailServicePort } from '@libs/email/services/email.service-port';
 import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions/http-conflict.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';

--- a/src/features/user/commands/send-verification-email/send-verification-email.command.ts
+++ b/src/features/user/commands/send-verification-email/send-verification-email.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class SendVerificationEmailCommand extends Command implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/user/commands/send-verification-email/send-verification-email.command.ts
+++ b/src/features/user/commands/send-verification-email/send-verification-email.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/user/commands/update-user-password/update-user-password.command-handler.ts
+++ b/src/features/user/commands/update-user-password/update-user-password.command-handler.ts
@@ -15,7 +15,7 @@ import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-c
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import bcrypt from 'bcrypt';
 @CommandHandler(UpdateUserPasswordCommand)
 export class UpdateUserPasswordCommandHandler

--- a/src/features/user/commands/update-user-password/update-user-password.command-handler.ts
+++ b/src/features/user/commands/update-user-password/update-user-password.command-handler.ts
@@ -1,11 +1,11 @@
 import { UpdateUserPasswordCommand } from '@features/user/commands/update-user-password/update-user-password.command';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { UserVerifyTokenType } from '@features/user/types/user.constant';
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
+import { Key } from '@libs/core/app-config/types/app-config.type';
 import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions/http-conflict.exception';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';

--- a/src/features/user/commands/update-user-password/update-user-password.command.ts
+++ b/src/features/user/commands/update-user-password/update-user-password.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/user/commands/update-user-password/update-user-password.command.ts
+++ b/src/features/user/commands/update-user-password/update-user-password.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class UpdateUserPasswordCommand extends Command implements ICommand {
   readonly token: string;

--- a/src/features/user/commands/verify-user-email/verify-user-email.command-handler.ts
+++ b/src/features/user/commands/verify-user-email/verify-user-email.command-handler.ts
@@ -11,7 +11,7 @@ import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-c
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject, UnauthorizedException } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(VerifyUserEmailCommand)
 export class VerifyUserEmailCommandHandler

--- a/src/features/user/commands/verify-user-email/verify-user-email.command-handler.ts
+++ b/src/features/user/commands/verify-user-email/verify-user-email.command-handler.ts
@@ -1,5 +1,5 @@
 import { VerifyUserEmailCommand } from '@features/user/commands/verify-user-email/verify-user-email.command';
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { UserVerifyTokenType } from '@features/user/types/user.constant';
 import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions/http-conflict.exception';

--- a/src/features/user/commands/verify-user-email/verify-user-email.command.ts
+++ b/src/features/user/commands/verify-user-email/verify-user-email.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/user/commands/verify-user-email/verify-user-email.command.ts
+++ b/src/features/user/commands/verify-user-email/verify-user-email.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class VerifyUserEmailCommand extends Command implements ICommand {
   readonly userId: AggregateID;

--- a/src/features/user/controllers/user.controller.ts
+++ b/src/features/user/controllers/user.controller.ts
@@ -6,26 +6,26 @@ import { SendVerificationEmailCommand } from '@features/user/commands/send-verif
 import { UpdateUserPasswordCommand } from '@features/user/commands/update-user-password/update-user-password.command';
 import { VerifyUserEmailCommand } from '@features/user/commands/verify-user-email/verify-user-email.command';
 import { ApiUser } from '@features/user/controllers/user.swagger';
-import type { UserEntity } from '@features/user/domain/user.entity';
-import type { FindUsersRequestQueryDto } from '@features/user/dtos/request/find-users.request-query-dto';
-import type { PatchUpdateUserRequestBodyDto } from '@features/user/dtos/request/patch-update-user.request-body-dto';
-import type { SendPasswordChangeVerificationEmailRequestDto } from '@features/user/dtos/request/send-password-change-verification-email.request-dto';
-import type { UpdatePasswordRequestDto } from '@features/user/dtos/request/update-password.request-dto';
+import { UserEntity } from '@features/user/domain/user.entity';
+import { FindUsersRequestQueryDto } from '@features/user/dtos/request/find-users.request-query-dto';
+import { PatchUpdateUserRequestBodyDto } from '@features/user/dtos/request/patch-update-user.request-body-dto';
+import { SendPasswordChangeVerificationEmailRequestDto } from '@features/user/dtos/request/send-password-change-verification-email.request-dto';
+import { UpdatePasswordRequestDto } from '@features/user/dtos/request/update-password.request-dto';
 import { UserResponseDto } from '@features/user/dtos/response/user.response-dto';
-import type { UserMapper } from '@features/user/mappers/user.mapper';
+import { UserMapper } from '@features/user/mappers/user.mapper';
 import { FindOneUserQuery } from '@features/user/queries/find-one-user/find-one-user.query';
-import type { FindOneUserQueryHandler } from '@features/user/queries/find-one-user/find-one-user.query-handler';
+import { FindOneUserQueryHandler } from '@features/user/queries/find-one-user/find-one-user.query-handler';
 import { FindUsersQuery } from '@features/user/queries/find-users/find-users.query';
 import { ApiInternalServerErrorBuilder } from '@libs/api/decorators/api-internal-server-error-builder.decorator';
 import { User } from '@libs/api/decorators/user.decorator';
 import { NotEmptyObjectPipe } from '@libs/api/pipes/not-empty-object.pipe';
 import { ParseEmailPipe } from '@libs/api/pipes/parse-email.pipe';
 import { ParsePositiveBigIntPipe } from '@libs/api/pipes/parse-positive-int.pipe';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { SetGuardType } from '@libs/guards/decorators/set-guard-type.decorator';
 import { GuardType } from '@libs/guards/types/guard.constant';
 import { SetPagination } from '@libs/interceptors/pagination/decorators/pagination-interceptor.decorator';
-import type { HandlerReturnType, Paginated } from '@libs/types/type';
+import { HandlerReturnType, Paginated } from '@libs/types/type';
 import {
   Body,
   Controller,
@@ -40,7 +40,7 @@ import {
   Put,
   Query,
 } from '@nestjs/common';
-import type { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { ApiExcludeEndpoint, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { FormDataRequest } from 'nestjs-form-data';
 

--- a/src/features/user/controllers/user.swagger.ts
+++ b/src/features/user/controllers/user.swagger.ts
@@ -10,7 +10,7 @@ import {
   getSchemaPath,
 } from '@nestjs/swagger';
 
-import type { UserController } from '@features/user/controllers/user.controller';
+import { UserController } from '@features/user/controllers/user.controller';
 import { UserResponseDto } from '@features/user/dtos/response/user.response-dto';
 import { UserMbti } from '@features/user/types/user.constant';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
@@ -23,10 +23,7 @@ import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-c
 import { CursorPaginationResponseDto } from '@libs/interceptors/pagination/dtos/cursor-pagination-interceptor.response-dto';
 import { OffsetPaginationResponseDto } from '@libs/interceptors/pagination/dtos/offset-pagination-interceptor.response-dto';
 import { CustomValidationError } from '@libs/types/custom-validation-errors.type';
-import type {
-  ApiOperationOptionsWithSummary,
-  ApiOperator,
-} from '@libs/types/type';
+import { ApiOperationOptionsWithSummary, ApiOperator } from '@libs/types/type';
 
 export const ApiUser: ApiOperator<keyof Omit<UserController, 'verifyEmail'>> = {
   FindUsers: (

--- a/src/features/user/domain/events/user-connection-disconnected.domain-event.ts
+++ b/src/features/user/domain/events/user-connection-disconnected.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 import { AggregateID } from '@libs/ddd/entity.base';
 
 export class UserConnectionDisconnectedDomainEvent extends DomainEvent {

--- a/src/features/user/domain/events/user-connection-disconnected.domain-event.ts
+++ b/src/features/user/domain/events/user-connection-disconnected.domain-event.ts
@@ -2,7 +2,7 @@ import {
   DomainEvent,
   type DomainEventProps,
 } from '@libs/ddd/base-domain.event';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export class UserConnectionDisconnectedDomainEvent extends DomainEvent {
   readonly connectionId: AggregateID;

--- a/src/features/user/domain/events/user-created.event.ts
+++ b/src/features/user/domain/events/user-created.event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 
 import { UserLoginTypeUnion } from '@features/user/types/user.type';
 

--- a/src/features/user/domain/events/user-created.event.ts
+++ b/src/features/user/domain/events/user-created.event.ts
@@ -3,7 +3,7 @@ import {
   type DomainEventProps,
 } from '@libs/ddd/base-domain.event';
 
-import type { UserLoginTypeUnion } from '@features/user/types/user.type';
+import { UserLoginTypeUnion } from '@features/user/types/user.type';
 
 export class UserCreatedDomainEvent extends DomainEvent {
   readonly email: string;

--- a/src/features/user/domain/events/user-deleted.domain-event.ts
+++ b/src/features/user/domain/events/user-deleted.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 
 export class UserDeletedDomainEvent extends DomainEvent {
   constructor(props: DomainEventProps<UserDeletedDomainEvent>) {

--- a/src/features/user/domain/events/user-is-email-verified-modified.event.ts
+++ b/src/features/user/domain/events/user-is-email-verified-modified.event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 
 export class UserIsEmailVerifiedUpdatedDomainEvent extends DomainEvent {
   readonly oldIsEmailVerified: boolean;

--- a/src/features/user/domain/events/user-password-updated.event.ts
+++ b/src/features/user/domain/events/user-password-updated.event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 
 export class UserPasswordUpdatedDomainEvent extends DomainEvent {
   readonly oldPassword: string;

--- a/src/features/user/domain/events/user-profile-image-path-updated.domain-event.ts
+++ b/src/features/user/domain/events/user-profile-image-path-updated.domain-event.ts
@@ -2,8 +2,8 @@ import {
   DomainEvent,
   type DomainEventProps,
 } from '@libs/ddd/base-domain.event';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { FileProps } from '@libs/types/type';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { FileProps } from '@libs/types/type';
 
 export class UserProfileImagePathUpdatedDomainEvent extends DomainEvent {
   readonly profileImageFile:

--- a/src/features/user/domain/events/user-profile-image-path-updated.domain-event.ts
+++ b/src/features/user/domain/events/user-profile-image-path-updated.domain-event.ts
@@ -1,7 +1,4 @@
-import {
-  DomainEvent,
-  type DomainEventProps,
-} from '@libs/ddd/base-domain.event';
+import { DomainEvent, DomainEventProps } from '@libs/ddd/base-domain.event';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { FileProps } from '@libs/types/type';
 

--- a/src/features/user/domain/user-verify-token/user-verify-token.entity-interface.ts
+++ b/src/features/user/domain/user-verify-token/user-verify-token.entity-interface.ts
@@ -1,5 +1,5 @@
-import type { UserVerifyTokenTypeUnion } from '@features/user/types/user.type';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { UserVerifyTokenTypeUnion } from '@features/user/types/user.type';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export interface UserVerifyTokenProps {
   userId: AggregateID;

--- a/src/features/user/domain/user-verify-token/user-verify-token.entity.ts
+++ b/src/features/user/domain/user-verify-token/user-verify-token.entity.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import type {
+import {
   CreateUserVerifyTokenProps,
   UserVerifyTokenProps,
 } from '@features/user/domain/user-verify-token/user-verify-token.entity-interface';

--- a/src/features/user/domain/user.entity-interface.ts
+++ b/src/features/user/domain/user.entity-interface.ts
@@ -1,11 +1,11 @@
-import type { UserVerifyTokenEntity } from '@features/user/domain/user-verify-token/user-verify-token.entity';
-import type {
+import { UserVerifyTokenEntity } from '@features/user/domain/user-verify-token/user-verify-token.entity';
+import {
   UserLoginTypeUnion,
   UserMbtiUnion,
   UserRoleUnion,
 } from '@features/user/types/user.type';
-import type { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
-import type { BaseEntityProps } from '@libs/ddd/entity.base';
+import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
+import { BaseEntityProps } from '@libs/ddd/entity.base';
 
 export interface UserProps {
   nickname: string;

--- a/src/features/user/domain/user.entity.ts
+++ b/src/features/user/domain/user.entity.ts
@@ -12,24 +12,24 @@ import { UserDeletedDomainEvent } from '@features/user/domain/events/user-delete
 import { UserIsEmailVerifiedUpdatedDomainEvent } from '@features/user/domain/events/user-is-email-verified-modified.event';
 import { UserPasswordUpdatedDomainEvent } from '@features/user/domain/events/user-password-updated.event';
 import { UserProfileImagePathUpdatedDomainEvent } from '@features/user/domain/events/user-profile-image-path-updated.domain-event';
-import type {
+import {
   CreateUserProps,
   HydratedUserEntityProps,
   UserProps,
 } from '@features/user/domain/user.entity-interface';
-import type { UserMbtiUnion } from '@features/user/types/user.type';
+import { UserMbtiUnion } from '@features/user/types/user.type';
 import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
-import type { CreateUserConnectionProps } from '@features/user/user-connection/domain/user-connection.entity-interface';
+import { CreateUserConnectionProps } from '@features/user/user-connection/domain/user-connection.entity-interface';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpUnprocessableEntityException } from '@libs/exceptions/client-errors/exceptions/http-unprocessable-entity.exception';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
 import { Guard } from '@libs/guard';
-import type { FileProps } from '@libs/types/type';
+import { FileProps } from '@libs/types/type';
 import { isNil } from '@libs/utils/util';
 import bcrypt from 'bcrypt';
 import { getTsid } from 'tsid-ts';

--- a/src/features/user/dtos/request/find-users.request-query-dto.ts
+++ b/src/features/user/dtos/request/find-users.request-query-dto.ts
@@ -1,9 +1,9 @@
-import type { UserModel } from '@features/user/mappers/user.mapper';
+import { UserModel } from '@features/user/mappers/user.mapper';
 import { CursorPaginationRequestQueryDto } from '@libs/api/dtos/request/cursor-pagination.request-query-dto';
 import { ParseQueryByColonAndTransformToObject } from '@libs/api/transformers/parse-query-by-colon-and-transform-to-object.transformer';
 import { transformStringToBoolean } from '@libs/api/transformers/transform-string-to-boolean.transformer';
 import { SortOrder } from '@libs/api/types/api.constant';
-import type { CursorBy, OrderBy } from '@libs/api/types/api.type';
+import { CursorBy, OrderBy } from '@libs/api/types/api.type';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsBoolean, IsOptional, Length, MinLength } from 'class-validator';

--- a/src/features/user/dtos/request/patch-update-user.request-body-dto.ts
+++ b/src/features/user/dtos/request/patch-update-user.request-body-dto.ts
@@ -10,7 +10,7 @@ import {
   HasMimeType,
   IsFile,
   MaxFileSize,
-  type MemoryStoredFile,
+  MemoryStoredFile,
 } from 'nestjs-form-data';
 
 export class PatchUpdateUserRequestBodyDto {

--- a/src/features/user/dtos/request/patch-update-user.request-body-dto.ts
+++ b/src/features/user/dtos/request/patch-update-user.request-body-dto.ts
@@ -1,7 +1,7 @@
 import { AttachmentEntity } from '@features/attachment/domain/attachment.entity';
 import { UserEntity } from '@features/user/domain/user.entity';
 import { UserMbti } from '@features/user/types/user.constant';
-import type { UserMbtiUnion } from '@features/user/types/user.type';
+import { UserMbtiUnion } from '@features/user/types/user.type';
 import { IsNullable } from '@libs/api/decorators/is-nullable.decorator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';

--- a/src/features/user/dtos/response/hydrated-user.response-dto.ts
+++ b/src/features/user/dtos/response/hydrated-user.response-dto.ts
@@ -1,6 +1,6 @@
 import {
   BaseResponseDto,
-  type CreateBaseResponseDtoProps,
+  CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
 import { ApiProperty } from '@nestjs/swagger';
 

--- a/src/features/user/dtos/response/user.response-dto.ts
+++ b/src/features/user/dtos/response/user.response-dto.ts
@@ -5,7 +5,7 @@ import {
 } from '@features/user/types/user.type';
 import {
   BaseResponseDto,
-  type CreateBaseResponseDtoProps,
+  CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
 import { ApiProperty } from '@nestjs/swagger';
 

--- a/src/features/user/dtos/response/user.response-dto.ts
+++ b/src/features/user/dtos/response/user.response-dto.ts
@@ -1,5 +1,5 @@
 import { UserLoginType, UserMbti } from '@features/user/types/user.constant';
-import type {
+import {
   UserLoginTypeUnion,
   UserMbtiUnion,
 } from '@features/user/types/user.type';

--- a/src/features/user/mappers/user-verify-token.mapper.ts
+++ b/src/features/user/mappers/user-verify-token.mapper.ts
@@ -2,11 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { z } from 'zod';
 
 import { UserVerifyTokenEntity } from '@features/user/domain/user-verify-token/user-verify-token.entity';
-import type { UserVerifyTokenProps } from '@features/user/domain/user-verify-token/user-verify-token.entity-interface';
+import { UserVerifyTokenProps } from '@features/user/domain/user-verify-token/user-verify-token.entity-interface';
 import { UserVerifyTokenType } from '@features/user/types/user.constant';
 import { baseSchema } from '@libs/db/base.schema';
-import type { CreateEntityProps } from '@libs/ddd/entity.base';
-import type { Mapper } from '@libs/ddd/mapper.interface';
+import { CreateEntityProps } from '@libs/ddd/entity.base';
+import { Mapper } from '@libs/ddd/mapper.interface';
 
 export const userVerifyTokenSchema = baseSchema
   .extend({

--- a/src/features/user/mappers/user.mapper.ts
+++ b/src/features/user/mappers/user.mapper.ts
@@ -2,7 +2,7 @@ import { UserEntity } from '@features/user/domain/user.entity';
 import { UserProps } from '@features/user/domain/user.entity-interface';
 import { UserResponseDto } from '@features/user/dtos/response/user.response-dto';
 import {
-  type UserVerifyTokenMapper,
+  UserVerifyTokenMapper,
   userVerifyTokenSchema,
 } from '@features/user/mappers/user-verify-token.mapper';
 import {
@@ -11,7 +11,7 @@ import {
   UserRole,
 } from '@features/user/types/user.constant';
 import {
-  type UserConnectionMapper,
+  UserConnectionMapper,
   userConnectionSchema,
 } from '@features/user/user-connection/mappers/user-connection.mapper';
 import { baseSchema } from '@libs/db/base.schema';

--- a/src/features/user/mappers/user.mapper.ts
+++ b/src/features/user/mappers/user.mapper.ts
@@ -1,5 +1,5 @@
 import { UserEntity } from '@features/user/domain/user.entity';
-import type { UserProps } from '@features/user/domain/user.entity-interface';
+import { UserProps } from '@features/user/domain/user.entity-interface';
 import { UserResponseDto } from '@features/user/dtos/response/user.response-dto';
 import {
   type UserVerifyTokenMapper,
@@ -15,8 +15,8 @@ import {
   userConnectionSchema,
 } from '@features/user/user-connection/mappers/user-connection.mapper';
 import { baseSchema } from '@libs/db/base.schema';
-import type { CreateEntityProps } from '@libs/ddd/entity.base';
-import type { Mapper } from '@libs/ddd/mapper.interface';
+import { CreateEntityProps } from '@libs/ddd/entity.base';
+import { Mapper } from '@libs/ddd/mapper.interface';
 import { isNil } from '@libs/utils/util';
 import { Injectable } from '@nestjs/common';
 import { z } from 'zod';

--- a/src/features/user/queries/find-one-user/find-one-user.query-handler.ts
+++ b/src/features/user/queries/find-one-user/find-one-user.query-handler.ts
@@ -6,7 +6,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { isNil } from '@libs/utils/util';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
-import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindOneUserQuery)
 export class FindOneUserQueryHandler

--- a/src/features/user/queries/find-one-user/find-one-user.query-handler.ts
+++ b/src/features/user/queries/find-one-user/find-one-user.query-handler.ts
@@ -1,11 +1,11 @@
 import { UserEntity } from '@features/user/domain/user.entity';
 import { FindOneUserQuery } from '@features/user/queries/find-one-user/find-one-user.query';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindOneUserQuery)

--- a/src/features/user/queries/find-one-user/find-one-user.query.ts
+++ b/src/features/user/queries/find-one-user/find-one-user.query.ts
@@ -1,6 +1,6 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { QueryBase } from '@libs/ddd/query.base';
-import type { IQuery } from '@nestjs/cqrs';
+import { IQuery } from '@nestjs/cqrs';
 
 export class FindOneUserQuery extends QueryBase implements IQuery {
   readonly userId: AggregateID;

--- a/src/features/user/queries/find-users/find-users.query-handler.ts
+++ b/src/features/user/queries/find-users/find-users.query-handler.ts
@@ -1,10 +1,10 @@
-import type { UserEntity } from '@features/user/domain/user.entity';
-import type { UserMapper } from '@features/user/mappers/user.mapper';
+import { UserEntity } from '@features/user/domain/user.entity';
+import { UserMapper } from '@features/user/mappers/user.mapper';
 import { FindUsersQuery } from '@features/user/queries/find-users/find-users.query';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { Paginated } from '@libs/types/type';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { Paginated } from '@libs/types/type';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindUsersQuery)

--- a/src/features/user/queries/find-users/find-users.query-handler.ts
+++ b/src/features/user/queries/find-users/find-users.query-handler.ts
@@ -5,7 +5,7 @@ import { PrismaService } from '@libs/core/prisma/services/prisma.service';
 import { Paginated } from '@libs/types/type';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
-import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindUsersQuery)
 export class FindUsersQueryHandler

--- a/src/features/user/queries/find-users/find-users.query.ts
+++ b/src/features/user/queries/find-users/find-users.query.ts
@@ -1,4 +1,4 @@
-import { type PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
+import { PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
 import { IQuery } from '@nestjs/cqrs';
 
 export class FindUsersQuery extends PaginatedQueryBase implements IQuery {

--- a/src/features/user/queries/find-users/find-users.query.ts
+++ b/src/features/user/queries/find-users/find-users.query.ts
@@ -1,5 +1,5 @@
 import { type PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
-import type { IQuery } from '@nestjs/cqrs';
+import { IQuery } from '@nestjs/cqrs';
 
 export class FindUsersQuery extends PaginatedQueryBase implements IQuery {
   readonly email?: string;

--- a/src/features/user/repositories/user.repository-port.ts
+++ b/src/features/user/repositories/user.repository-port.ts
@@ -1,10 +1,10 @@
-import type { UserVerifyTokenEntity } from '@features/user/domain/user-verify-token/user-verify-token.entity';
-import type { UserEntity } from '@features/user/domain/user.entity';
-import type { UserLoginTypeUnion } from '@features/user/types/user.type';
-import type { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { RepositoryPort } from '@libs/ddd/repository.port';
+import { UserVerifyTokenEntity } from '@features/user/domain/user-verify-token/user-verify-token.entity';
+import { UserEntity } from '@features/user/domain/user.entity';
+import { UserLoginTypeUnion } from '@features/user/types/user.type';
+import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface UserInclude {
   userVerifyTokens?: boolean;

--- a/src/features/user/repositories/user.repository.ts
+++ b/src/features/user/repositories/user.repository.ts
@@ -1,21 +1,21 @@
-import type { UserVerifyTokenEntity } from '@features/user/domain/user-verify-token/user-verify-token.entity';
-import type { UserEntity } from '@features/user/domain/user.entity';
-import type { UserVerifyTokenMapper } from '@features/user/mappers/user-verify-token.mapper';
-import type { UserMapper } from '@features/user/mappers/user.mapper';
-import type {
+import { UserVerifyTokenEntity } from '@features/user/domain/user-verify-token/user-verify-token.entity';
+import { UserEntity } from '@features/user/domain/user.entity';
+import { UserVerifyTokenMapper } from '@features/user/mappers/user-verify-token.mapper';
+import { UserMapper } from '@features/user/mappers/user.mapper';
+import {
   UserInclude,
   UserRepositoryPort,
 } from '@features/user/repositories/user.repository-port';
-import type { UserLoginTypeUnion } from '@features/user/types/user.type';
-import type { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
-import type { UserConnectionMapper } from '@features/user/user-connection/mappers/user-connection.mapper';
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { UserLoginTypeUnion } from '@features/user/types/user.type';
+import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
+import { UserConnectionMapper } from '@features/user/user-connection/mappers/user-connection.mapper';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
-import type { EventEmitter2 } from '@nestjs/event-emitter';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 @Injectable()
 export class UserRepository implements UserRepositoryPort {

--- a/src/features/user/types/user.type.ts
+++ b/src/features/user/types/user.type.ts
@@ -1,10 +1,10 @@
-import type {
+import {
   UserLoginType,
   UserMbti,
   UserRole,
   UserVerifyTokenType,
 } from '@features/user/types/user.constant';
-import type { ValueOf } from '@libs/types/type';
+import { ValueOf } from '@libs/types/type';
 
 export type UserRoleUnion = ValueOf<typeof UserRole>;
 export type UserLoginTypeUnion = ValueOf<typeof UserLoginType>;

--- a/src/features/user/user-connection/commands/create-user-connection/create-user-connection.command-handler.ts
+++ b/src/features/user/user-connection/commands/create-user-connection/create-user-connection.command-handler.ts
@@ -1,8 +1,8 @@
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { CreateUserConnectionCommand } from '@features/user/user-connection/commands/create-user-connection/create-user-connection.command';
-import type { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions/http-conflict.exception';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';

--- a/src/features/user/user-connection/commands/create-user-connection/create-user-connection.command-handler.ts
+++ b/src/features/user/user-connection/commands/create-user-connection/create-user-connection.command-handler.ts
@@ -12,7 +12,7 @@ import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-c
 import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(CreateUserConnectionCommand)
 export class CreateUserConnectionCommandHandler

--- a/src/features/user/user-connection/commands/create-user-connection/create-user-connection.command.ts
+++ b/src/features/user/user-connection/commands/create-user-connection/create-user-connection.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class CreateUserConnectionCommand extends Command implements ICommand {
   readonly requesterId: AggregateID;

--- a/src/features/user/user-connection/commands/create-user-connection/create-user-connection.command.ts
+++ b/src/features/user/user-connection/commands/create-user-connection/create-user-connection.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/user/user-connection/commands/disconnect-user-connection/disconnect-user-connection.command-handler.ts
+++ b/src/features/user/user-connection/commands/disconnect-user-connection/disconnect-user-connection.command-handler.ts
@@ -11,7 +11,7 @@ import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-c
 import { isNil } from '@libs/utils/util';
 import { Transactional } from '@nestjs-cls/transactional';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(DisconnectUserConnectionCommand)
 export class DisconnectUserConnectionCommandHandler

--- a/src/features/user/user-connection/commands/disconnect-user-connection/disconnect-user-connection.command-handler.ts
+++ b/src/features/user/user-connection/commands/disconnect-user-connection/disconnect-user-connection.command-handler.ts
@@ -1,7 +1,7 @@
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { DisconnectUserConnectionCommand } from '@features/user/user-connection/commands/disconnect-user-connection/disconnect-user-connection.command';
-import type { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
+import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
 import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';

--- a/src/features/user/user-connection/commands/disconnect-user-connection/disconnect-user-connection.command.ts
+++ b/src/features/user/user-connection/commands/disconnect-user-connection/disconnect-user-connection.command.ts
@@ -1,6 +1,6 @@
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class DisconnectUserConnectionCommand
   extends Command

--- a/src/features/user/user-connection/commands/disconnect-user-connection/disconnect-user-connection.command.ts
+++ b/src/features/user/user-connection/commands/disconnect-user-connection/disconnect-user-connection.command.ts
@@ -1,4 +1,4 @@
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/user/user-connection/commands/update-user-connection/update-user-connection.command-handler.ts
+++ b/src/features/user/user-connection/commands/update-user-connection/update-user-connection.command-handler.ts
@@ -1,8 +1,8 @@
-import type { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
+import { UserRepositoryPort } from '@features/user/repositories/user.repository-port';
 import { USER_REPOSITORY_DI_TOKEN } from '@features/user/tokens/di.token';
 import { UpdateUserConnectionCommand } from '@features/user/user-connection/commands/update-user-connection/update-user-connection.command';
-import type { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
-import type { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
+import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
+import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
 import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';

--- a/src/features/user/user-connection/commands/update-user-connection/update-user-connection.command-handler.ts
+++ b/src/features/user/user-connection/commands/update-user-connection/update-user-connection.command-handler.ts
@@ -11,7 +11,7 @@ import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
 import { Inject } from '@nestjs/common';
-import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 @CommandHandler(UpdateUserConnectionCommand)
 export class UpdateUserConnectionCommandHandler

--- a/src/features/user/user-connection/commands/update-user-connection/update-user-connection.command.ts
+++ b/src/features/user/user-connection/commands/update-user-connection/update-user-connection.command.ts
@@ -1,7 +1,7 @@
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
 import { Command, type CommandProps } from '@libs/ddd/command.base';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { ICommand } from '@nestjs/cqrs';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { ICommand } from '@nestjs/cqrs';
 
 export class UpdateUserConnectionCommand extends Command implements ICommand {
   readonly userConnectionId: AggregateID;

--- a/src/features/user/user-connection/commands/update-user-connection/update-user-connection.command.ts
+++ b/src/features/user/user-connection/commands/update-user-connection/update-user-connection.command.ts
@@ -1,5 +1,5 @@
 import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
-import { Command, type CommandProps } from '@libs/ddd/command.base';
+import { Command, CommandProps } from '@libs/ddd/command.base';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ICommand } from '@nestjs/cqrs';
 

--- a/src/features/user/user-connection/controllers/user-connection.controller.ts
+++ b/src/features/user/user-connection/controllers/user-connection.controller.ts
@@ -3,20 +3,20 @@ import { CreateUserConnectionCommand } from '@features/user/user-connection/comm
 import { DisconnectUserConnectionCommand } from '@features/user/user-connection/commands/disconnect-user-connection/disconnect-user-connection.command';
 import { UpdateUserConnectionCommand } from '@features/user/user-connection/commands/update-user-connection/update-user-connection.command';
 import { ApiUserConnection } from '@features/user/user-connection/controllers/user-connection.swagger';
-import type { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
-import type { CreateUserConnectionRequestBodyDto } from '@features/user/user-connection/dtos/request/create-user-connection.request-body-dto';
-import type { FindUserConnectionsRequestQueryDto } from '@features/user/user-connection/dtos/request/find-user-connections.request-query-dto';
-import type { UpdateUserConnectionRequestBodyDto } from '@features/user/user-connection/dtos/request/update-user-connection.request-body-dto';
-import type { UserConnectionResponseDto } from '@features/user/user-connection/dtos/response/user-connection.response-dto';
-import type { UserConnectionMapper } from '@features/user/user-connection/mappers/user-connection.mapper';
+import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
+import { CreateUserConnectionRequestBodyDto } from '@features/user/user-connection/dtos/request/create-user-connection.request-body-dto';
+import { FindUserConnectionsRequestQueryDto } from '@features/user/user-connection/dtos/request/find-user-connections.request-query-dto';
+import { UpdateUserConnectionRequestBodyDto } from '@features/user/user-connection/dtos/request/update-user-connection.request-body-dto';
+import { UserConnectionResponseDto } from '@features/user/user-connection/dtos/response/user-connection.response-dto';
+import { UserConnectionMapper } from '@features/user/user-connection/mappers/user-connection.mapper';
 import { FindUserConnectionsQuery } from '@features/user/user-connection/queries/find-user-connections/find-user-connections.query';
 import { ApiInternalServerErrorBuilder } from '@libs/api/decorators/api-internal-server-error-builder.decorator';
 import { User } from '@libs/api/decorators/user.decorator';
 import { IdResponseDto } from '@libs/api/dtos/response/id.response-dto';
 import { ParsePositiveBigIntPipe } from '@libs/api/pipes/parse-positive-int.pipe';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { SetPagination } from '@libs/interceptors/pagination/decorators/pagination-interceptor.decorator';
-import type { Paginated } from '@libs/types/type';
+import { Paginated } from '@libs/types/type';
 import {
   Body,
   Controller,
@@ -29,7 +29,7 @@ import {
   Put,
   Query,
 } from '@nestjs/common';
-import type { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('UserConnection')

--- a/src/features/user/user-connection/controllers/user-connection.swagger.ts
+++ b/src/features/user/user-connection/controllers/user-connection.swagger.ts
@@ -1,4 +1,4 @@
-import type { UserConnectionController } from '@features/user/user-connection/controllers/user-connection.controller';
+import { UserConnectionController } from '@features/user/user-connection/controllers/user-connection.controller';
 import { UserConnectionResponseDto } from '@features/user/user-connection/dtos/response/user-connection.response-dto';
 import { IdResponseDto } from '@libs/api/dtos/response/id.response-dto';
 import { HttpStatus, applyDecorators } from '@nestjs/common';
@@ -19,10 +19,7 @@ import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-c
 import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-code.constant';
 import { OffsetPaginationResponseDto } from '@libs/interceptors/pagination/dtos/offset-pagination-interceptor.response-dto';
 import { CustomValidationError } from '@libs/types/custom-validation-errors.type';
-import type {
-  ApiOperationOptionsWithSummary,
-  ApiOperator,
-} from '@libs/types/type';
+import { ApiOperationOptionsWithSummary, ApiOperator } from '@libs/types/type';
 
 export const ApiUserConnection: ApiOperator<keyof UserConnectionController> = {
   Create: (

--- a/src/features/user/user-connection/domain/user-connection.entity-interface.ts
+++ b/src/features/user/user-connection/domain/user-connection.entity-interface.ts
@@ -1,8 +1,8 @@
-import type { HydratedBlogEntityProps } from '@features/blog/domain/blog.entity-interface';
-import type { HydratedChatRoomEntityProps } from '@features/chat-room/domain/chat-room.entity-interface';
-import type { HydratedUserEntityProps } from '@features/user/domain/user.entity-interface';
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { HydratedBlogEntityProps } from '@features/blog/domain/blog.entity-interface';
+import { HydratedChatRoomEntityProps } from '@features/chat-room/domain/chat-room.entity-interface';
+import { HydratedUserEntityProps } from '@features/user/domain/user.entity-interface';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export interface UserConnectionProps {
   requestedId: AggregateID;

--- a/src/features/user/user-connection/domain/user-connection.entity.ts
+++ b/src/features/user/user-connection/domain/user-connection.entity.ts
@@ -5,7 +5,7 @@ import {
 } from '@features/user/user-connection/domain/user-connection.entity-interface';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
-import { type AggregateID, Entity } from '@libs/ddd/entity.base';
+import { AggregateID, Entity } from '@libs/ddd/entity.base';
 import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions/http-conflict.exception';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';

--- a/src/features/user/user-connection/domain/user-connection.entity.ts
+++ b/src/features/user/user-connection/domain/user-connection.entity.ts
@@ -1,10 +1,10 @@
-import type { UserEntity } from '@features/user/domain/user.entity';
-import type {
+import { UserEntity } from '@features/user/domain/user.entity';
+import {
   CreateUserConnectionProps,
   UserConnectionProps,
 } from '@features/user/user-connection/domain/user-connection.entity-interface';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
 import { type AggregateID, Entity } from '@libs/ddd/entity.base';
 import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions/http-conflict.exception';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';

--- a/src/features/user/user-connection/dtos/request/create-user-connection.request-body-dto.ts
+++ b/src/features/user/user-connection/dtos/request/create-user-connection.request-body-dto.ts
@@ -1,5 +1,5 @@
 import { IsPositiveBigInt } from '@libs/api/decorators/is-positive-bigint.decorator';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateUserConnectionRequestBodyDto {

--- a/src/features/user/user-connection/dtos/request/find-user-connections.request-query-dto.ts
+++ b/src/features/user/user-connection/dtos/request/find-user-connections.request-query-dto.ts
@@ -1,11 +1,11 @@
-import type { UserConnectionModel } from '@features/user/user-connection/mappers/user-connection.mapper';
+import { UserConnectionModel } from '@features/user/user-connection/mappers/user-connection.mapper';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
 import { OffsetPaginationRequestQueryDto } from '@libs/api/dtos/request/offset-pagination.request-query-dto';
 import { ParseQueryByColonAndTransformToObject } from '@libs/api/transformers/parse-query-by-colon-and-transform-to-object.transformer';
 import { transformStringToBoolean } from '@libs/api/transformers/transform-string-to-boolean.transformer';
 import { SortOrder } from '@libs/api/types/api.constant';
-import type { OrderBy } from '@libs/api/types/api.type';
+import { OrderBy } from '@libs/api/types/api.type';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import {

--- a/src/features/user/user-connection/dtos/request/update-user-connection.request-body-dto.ts
+++ b/src/features/user/user-connection/dtos/request/update-user-connection.request-body-dto.ts
@@ -1,5 +1,5 @@
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum } from 'class-validator';
 

--- a/src/features/user/user-connection/dtos/response/user-connection.response-dto.ts
+++ b/src/features/user/user-connection/dtos/response/user-connection.response-dto.ts
@@ -3,7 +3,7 @@ import { UserConnectionStatus } from '@features/user/user-connection/types/user.
 import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
 import {
   BaseResponseDto,
-  type CreateBaseResponseDtoProps,
+  CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
 import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';

--- a/src/features/user/user-connection/dtos/response/user-connection.response-dto.ts
+++ b/src/features/user/user-connection/dtos/response/user-connection.response-dto.ts
@@ -1,11 +1,11 @@
 import { HydratedUserResponseDto } from '@features/user/dtos/response/hydrated-user.response-dto';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
 import {
   BaseResponseDto,
   type CreateBaseResponseDtoProps,
 } from '@libs/api/dtos/response/base.response-dto';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export interface CreateUserConnectionResponseDtoProps

--- a/src/features/user/user-connection/mappers/user-connection.mapper.ts
+++ b/src/features/user/user-connection/mappers/user-connection.mapper.ts
@@ -4,15 +4,15 @@ import { z } from 'zod';
 import { blogSchema } from '@features/blog/mappers/blog.mapper';
 import { chatRoomSchema } from '@features/chat-room/mappers/chat-room.mapper';
 import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
-import type { UserConnectionProps } from '@features/user/user-connection/domain/user-connection.entity-interface';
+import { UserConnectionProps } from '@features/user/user-connection/domain/user-connection.entity-interface';
 import {
   type CreateUserConnectionResponseDtoProps,
   UserConnectionResponseDto,
 } from '@features/user/user-connection/dtos/response/user-connection.response-dto';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
 import { baseSchema } from '@libs/db/base.schema';
-import type { AggregateID, CreateEntityProps } from '@libs/ddd/entity.base';
-import type { Mapper } from '@libs/ddd/mapper.interface';
+import { AggregateID, CreateEntityProps } from '@libs/ddd/entity.base';
+import { Mapper } from '@libs/ddd/mapper.interface';
 import { isNil } from '@libs/utils/util';
 import { HydratedUserResponseDto } from '@src/features/user/dtos/response/hydrated-user.response-dto';
 

--- a/src/features/user/user-connection/mappers/user-connection.mapper.ts
+++ b/src/features/user/user-connection/mappers/user-connection.mapper.ts
@@ -6,7 +6,7 @@ import { chatRoomSchema } from '@features/chat-room/mappers/chat-room.mapper';
 import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
 import { UserConnectionProps } from '@features/user/user-connection/domain/user-connection.entity-interface';
 import {
-  type CreateUserConnectionResponseDtoProps,
+  CreateUserConnectionResponseDtoProps,
   UserConnectionResponseDto,
 } from '@features/user/user-connection/dtos/response/user-connection.response-dto';
 import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';

--- a/src/features/user/user-connection/queries/find-user-connections/find-user-connections.query-handler.ts
+++ b/src/features/user/user-connection/queries/find-user-connections/find-user-connections.query-handler.ts
@@ -1,13 +1,13 @@
-import type { UserEntity } from '@features/user/domain/user.entity';
-import type { UserMapper } from '@features/user/mappers/user.mapper';
-import type { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
-import type { UserConnectionMapper } from '@features/user/user-connection/mappers/user-connection.mapper';
+import { UserEntity } from '@features/user/domain/user.entity';
+import { UserMapper } from '@features/user/mappers/user.mapper';
+import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
+import { UserConnectionMapper } from '@features/user/user-connection/mappers/user-connection.mapper';
 import { FindUserConnectionsQuery } from '@features/user/user-connection/queries/find-user-connections/find-user-connections.query';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { Paginated } from '@libs/types/type';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { Paginated } from '@libs/types/type';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindUserConnectionsQuery)

--- a/src/features/user/user-connection/queries/find-user-connections/find-user-connections.query-handler.ts
+++ b/src/features/user/user-connection/queries/find-user-connections/find-user-connections.query-handler.ts
@@ -8,7 +8,7 @@ import { AggregateID } from '@libs/ddd/entity.base';
 import { Paginated } from '@libs/types/type';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
-import { type IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 @QueryHandler(FindUserConnectionsQuery)
 export class FindUserConnectionsQueryHandler

--- a/src/features/user/user-connection/queries/find-user-connections/find-user-connections.query.ts
+++ b/src/features/user/user-connection/queries/find-user-connections/find-user-connections.query.ts
@@ -1,6 +1,6 @@
 import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
 import { AggregateID } from '@libs/ddd/entity.base';
-import { type PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
+import { PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
 import { IQuery } from '@nestjs/cqrs';
 
 export class FindUserConnectionsQuery

--- a/src/features/user/user-connection/queries/find-user-connections/find-user-connections.query.ts
+++ b/src/features/user/user-connection/queries/find-user-connections/find-user-connections.query.ts
@@ -1,7 +1,7 @@
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { type PaginatedParams, PaginatedQueryBase } from '@libs/ddd/query.base';
-import type { IQuery } from '@nestjs/cqrs';
+import { IQuery } from '@nestjs/cqrs';
 
 export class FindUserConnectionsQuery
   extends PaginatedQueryBase

--- a/src/features/user/user-connection/repositories/user-connection.repository-port.ts
+++ b/src/features/user/user-connection/repositories/user-connection.repository-port.ts
@@ -1,7 +1,7 @@
-import type { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { RepositoryPort } from '@libs/ddd/repository.port';
+import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { RepositoryPort } from '@libs/ddd/repository.port';
 
 export interface UserConnectionRepositoryPort
   extends RepositoryPort<UserConnectionEntity> {

--- a/src/features/user/user-connection/repositories/user-connection.repository.ts
+++ b/src/features/user/user-connection/repositories/user-connection.repository.ts
@@ -1,11 +1,11 @@
-import type { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
-import type { UserConnectionMapper } from '@features/user/user-connection/mappers/user-connection.mapper';
-import type { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
-import type { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { UserConnectionEntity } from '@features/user/user-connection/domain/user-connection.entity';
+import { UserConnectionMapper } from '@features/user/user-connection/mappers/user-connection.mapper';
+import { UserConnectionRepositoryPort } from '@features/user/user-connection/repositories/user-connection.repository-port';
+import { UserConnectionStatusUnion } from '@features/user/user-connection/types/user.type';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()

--- a/src/features/user/user-connection/types/user.type.ts
+++ b/src/features/user/user-connection/types/user.type.ts
@@ -1,4 +1,4 @@
-import type { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
-import type { ValueOf } from '@libs/types/type';
+import { UserConnectionStatus } from '@features/user/user-connection/types/user.constant';
+import { ValueOf } from '@libs/types/type';
 
 export type UserConnectionStatusUnion = ValueOf<typeof UserConnectionStatus>;

--- a/src/features/user/user.module.ts
+++ b/src/features/user/user.module.ts
@@ -23,7 +23,7 @@ import { UserConnectionRepository } from '@features/user/user-connection/reposit
 import { USER_CONNECTION_REPOSITORY_DI_TOKEN } from '@features/user/user-connection/tokens/di.token';
 import { EmailModule } from '@libs/email/email.module';
 import { Module } from '@nestjs/common';
-import type { Provider } from '@nestjs/common/interfaces';
+import { Provider } from '@nestjs/common/interfaces';
 import { NestjsFormDataModule } from 'nestjs-form-data';
 
 const controllers = [UserController, UserConnectionController];

--- a/src/libs/api/decorators/is-big-int.decorator.ts
+++ b/src/libs/api/decorators/is-big-int.decorator.ts
@@ -1,4 +1,4 @@
-import { type ValidationOptions, registerDecorator } from 'class-validator';
+import { ValidationOptions, registerDecorator } from 'class-validator';
 
 export function IsBigIntString(
   validationOptions?: ValidationOptions,

--- a/src/libs/api/decorators/is-positive-bigint.decorator.ts
+++ b/src/libs/api/decorators/is-positive-bigint.decorator.ts
@@ -2,7 +2,7 @@ import { IsBigIntString } from '@libs/api/decorators/is-big-int.decorator';
 import { MinForBigInt } from '@libs/api/decorators/min-for-bigint.decorator';
 import { applyDecorators } from '@nestjs/common';
 import { Transform } from 'class-transformer';
-import type { ValidationOptions } from 'class-validator';
+import { ValidationOptions } from 'class-validator';
 
 export function IsPositiveBigInt(
   validationOptions?: ValidationOptions,

--- a/src/libs/api/decorators/min-for-bigint.decorator.ts
+++ b/src/libs/api/decorators/min-for-bigint.decorator.ts
@@ -1,4 +1,4 @@
-import { type ValidationOptions, registerDecorator } from 'class-validator';
+import { ValidationOptions, registerDecorator } from 'class-validator';
 
 export function MinForBigInt(
   min: number,

--- a/src/libs/api/decorators/user.decorator.ts
+++ b/src/libs/api/decorators/user.decorator.ts
@@ -3,7 +3,7 @@ import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-e
 import { GUARD_TYPE_TOKEN, GuardType } from '@libs/guards/types/guard.constant';
 import { GuardTypeUnion } from '@libs/guards/types/guard.type';
 import { isNil } from '@libs/utils/util';
-import { type ExecutionContext, createParamDecorator } from '@nestjs/common';
+import { ExecutionContext, createParamDecorator } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 

--- a/src/libs/api/decorators/user.decorator.ts
+++ b/src/libs/api/decorators/user.decorator.ts
@@ -1,11 +1,11 @@
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { GUARD_TYPE_TOKEN, GuardType } from '@libs/guards/types/guard.constant';
-import type { GuardTypeUnion } from '@libs/guards/types/guard.type';
+import { GuardTypeUnion } from '@libs/guards/types/guard.type';
 import { isNil } from '@libs/utils/util';
 import { type ExecutionContext, createParamDecorator } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import type { Request } from 'express';
+import { Request } from 'express';
 
 export const User = createParamDecorator(
   (data: keyof Express.User | undefined, ctx: ExecutionContext) => {

--- a/src/libs/api/dtos/request/cursor-pagination.request-query-dto.ts
+++ b/src/libs/api/dtos/request/cursor-pagination.request-query-dto.ts
@@ -1,6 +1,6 @@
 import { PaginationBaseRequestQueryDto } from '@libs/api/dtos/request/pagination-base.request-query-dto';
-import type { CursorBy } from '@libs/api/types/api.type';
-import type { BaseModel } from '@libs/db/base.schema';
+import { CursorBy } from '@libs/api/types/api.type';
+import { BaseModel } from '@libs/db/base.schema';
 
 /**
  * pagination 을 구현하는 request query dto 에 상속받아 사용합니다.

--- a/src/libs/api/dtos/request/offset-pagination.request-query-dto.ts
+++ b/src/libs/api/dtos/request/offset-pagination.request-query-dto.ts
@@ -1,5 +1,5 @@
 import { PaginationBaseRequestQueryDto } from '@libs/api/dtos/request/pagination-base.request-query-dto';
-import type { BaseModel } from '@libs/db/base.schema';
+import { BaseModel } from '@libs/db/base.schema';
 
 /**
  * pagination 을 구현하는 request query dto 에 상속받아 사용합니다.

--- a/src/libs/api/dtos/request/pagination-base.request-query-dto.ts
+++ b/src/libs/api/dtos/request/pagination-base.request-query-dto.ts
@@ -1,7 +1,7 @@
 import { transformPage } from '@libs/api/transformers/page.transformer';
 import { PageLimit, SortOrder } from '@libs/api/types/api.constant';
-import type { OrderBy, SortOrderUnion } from '@libs/api/types/api.type';
-import type { BaseModel } from '@libs/db/base.schema';
+import { OrderBy, SortOrderUnion } from '@libs/api/types/api.type';
+import { BaseModel } from '@libs/db/base.schema';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 import { Transform, Type } from 'class-transformer';

--- a/src/libs/api/dtos/response/base.response-dto.ts
+++ b/src/libs/api/dtos/response/base.response-dto.ts
@@ -1,5 +1,5 @@
 import { IdResponseDto } from '@libs/api/dtos/response/id.response-dto';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty } from '@nestjs/swagger';
 
 export interface CreateBaseResponseDtoProps {

--- a/src/libs/api/dtos/response/id.response-dto.ts
+++ b/src/libs/api/dtos/response/id.response-dto.ts
@@ -1,4 +1,4 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class IdResponseDto {

--- a/src/libs/api/pipes/not-empty-object.pipe.ts
+++ b/src/libs/api/pipes/not-empty-object.pipe.ts
@@ -2,11 +2,7 @@ import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptio
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { isNil } from '@libs/utils/util';
-import {
-  type ArgumentMetadata,
-  Injectable,
-  type PipeTransform,
-} from '@nestjs/common';
+import { ArgumentMetadata, Injectable, PipeTransform } from '@nestjs/common';
 
 @Injectable()
 export class NotEmptyObjectPipe implements PipeTransform {

--- a/src/libs/api/pipes/parse-email.pipe.ts
+++ b/src/libs/api/pipes/parse-email.pipe.ts
@@ -1,10 +1,6 @@
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
-import {
-  type ArgumentMetadata,
-  Injectable,
-  type PipeTransform,
-} from '@nestjs/common';
+import { ArgumentMetadata, Injectable, PipeTransform } from '@nestjs/common';
 import { isEmail } from 'class-validator';
 
 @Injectable()

--- a/src/libs/api/pipes/parse-positive-int.pipe.spec.ts
+++ b/src/libs/api/pipes/parse-positive-int.pipe.spec.ts
@@ -1,6 +1,6 @@
 import { ParsePositiveBigIntPipe } from '@libs/api/pipes/parse-positive-int.pipe';
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
-import type { ArgumentMetadata } from '@nestjs/common';
+import { ArgumentMetadata } from '@nestjs/common';
 
 describe(ParsePositiveBigIntPipe.name, () => {
   let target: ParsePositiveBigIntPipe;

--- a/src/libs/api/pipes/parse-positive-int.pipe.ts
+++ b/src/libs/api/pipes/parse-positive-int.pipe.ts
@@ -1,10 +1,10 @@
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import {
-  type ArgumentMetadata,
+  ArgumentMetadata,
   Injectable,
   Optional,
-  type PipeTransform,
+  PipeTransform,
 } from '@nestjs/common';
 
 interface Options {

--- a/src/libs/api/transformers/parse-query-by-colon-and-transform-to-object.transformer.ts
+++ b/src/libs/api/transformers/parse-query-by-colon-and-transform-to-object.transformer.ts
@@ -1,6 +1,6 @@
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
-import type { SingleProperty } from '@libs/types/type';
+import { SingleProperty } from '@libs/types/type';
 import { applyDecorators } from '@nestjs/common';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';

--- a/src/libs/api/types/api.type.ts
+++ b/src/libs/api/types/api.type.ts
@@ -1,5 +1,5 @@
-import type { SortOrder } from '@libs/api/types/api.constant';
-import type { ValueOf } from '@libs/types/type';
+import { SortOrder } from '@libs/api/types/api.constant';
+import { ValueOf } from '@libs/types/type';
 
 export type SortOrderUnion = ValueOf<typeof SortOrder>;
 

--- a/src/libs/app-jwt/factories/jwt-module-options.factory.ts
+++ b/src/libs/app-jwt/factories/jwt-module-options.factory.ts
@@ -1,9 +1,9 @@
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
+import { Key } from '@libs/core/app-config/types/app-config.type';
 import { Inject, Injectable } from '@nestjs/common';
-import type { JwtModuleOptions, JwtOptionsFactory } from '@nestjs/jwt';
+import { JwtModuleOptions, JwtOptionsFactory } from '@nestjs/jwt';
 
 @Injectable()
 export class JwtModuleOptionsFactory implements JwtOptionsFactory {

--- a/src/libs/app-jwt/services/app-jwt.service-port.ts
+++ b/src/libs/app-jwt/services/app-jwt.service-port.ts
@@ -1,4 +1,4 @@
-import type { JwtPayload } from '@libs/app-jwt/types/app-jwt.interface';
+import { JwtPayload } from '@libs/app-jwt/types/app-jwt.interface';
 
 export interface AppJwtServicePort {
   generateToken(payload: JwtPayload): Promise<string>;

--- a/src/libs/app-jwt/services/app-jwt.service.ts
+++ b/src/libs/app-jwt/services/app-jwt.service.ts
@@ -1,14 +1,14 @@
-import type { AppJwtServicePort } from '@libs/app-jwt/services/app-jwt.service-port';
+import { AppJwtServicePort } from '@libs/app-jwt/services/app-jwt.service-port';
 import { TokenType } from '@libs/app-jwt/types/app-jwt.enum';
-import type { JwtPayload } from '@libs/app-jwt/types/app-jwt.interface';
+import { JwtPayload } from '@libs/app-jwt/types/app-jwt.interface';
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
+import { Key } from '@libs/core/app-config/types/app-config.type';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { Inject, Injectable } from '@nestjs/common';
-import type { JwtService } from '@nestjs/jwt';
+import { JwtService } from '@nestjs/jwt';
 
 @Injectable()
 export class AppJwtService implements AppJwtServicePort {

--- a/src/libs/app-jwt/types/app-jwt.interface.ts
+++ b/src/libs/app-jwt/types/app-jwt.interface.ts
@@ -1,4 +1,4 @@
-import type { TokenType } from '@libs/app-jwt/types/app-jwt.enum';
+import { TokenType } from '@libs/app-jwt/types/app-jwt.enum';
 
 export interface JwtPayload {
   sub: string;

--- a/src/libs/application/context/app-request.context.ts
+++ b/src/libs/application/context/app-request.context.ts
@@ -1,6 +1,6 @@
-import type { PrismaService } from '@libs/core/prisma/services/prisma.service';
-import type { TransactionHost } from '@nestjs-cls/transactional';
-import type { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
+import { PrismaService } from '@libs/core/prisma/services/prisma.service';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterPrisma } from '@nestjs-cls/transactional-adapter-prisma';
 import { RequestContext } from 'nestjs-request-context';
 
 /**

--- a/src/libs/core/app-config/app-config.module.ts
+++ b/src/libs/core/app-config/app-config.module.ts
@@ -1,9 +1,4 @@
-import {
-  Global,
-  Inject,
-  Module,
-  type OnApplicationBootstrap,
-} from '@nestjs/common';
+import { Global, Inject, Module, OnApplicationBootstrap } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 
 import * as Joi from 'joi';

--- a/src/libs/core/app-config/app-config.module.ts
+++ b/src/libs/core/app-config/app-config.module.ts
@@ -10,9 +10,9 @@ import * as Joi from 'joi';
 
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
 import { AppConfigService } from '@libs/core/app-config/services/app-config.service';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
+import { Key } from '@libs/core/app-config/types/app-config.type';
 
 @Global()
 @Module({

--- a/src/libs/core/app-config/services/app-config.service.ts
+++ b/src/libs/core/app-config/services/app-config.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import type { ConfigService } from '@nestjs/config';
+import { ConfigService } from '@nestjs/config';
 
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { Key } from '@libs/core/app-config/types/app-config.type';
 
 @Injectable()
 export class AppConfigService implements AppConfigServicePort<Key> {

--- a/src/libs/core/app-config/types/app-config.type.ts
+++ b/src/libs/core/app-config/types/app-config.type.ts
@@ -1,3 +1,3 @@
-import type { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
+import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
 
 export type Key = keyof typeof ENV_KEY;

--- a/src/libs/core/prisma/services/prisma.service.ts
+++ b/src/libs/core/prisma/services/prisma.service.ts
@@ -1,10 +1,10 @@
 import {
   Injectable,
   Logger,
-  type OnModuleDestroy,
-  type OnModuleInit,
+  OnModuleDestroy,
+  OnModuleInit,
 } from '@nestjs/common';
-import { type Prisma, PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 
 @Injectable()
 export class PrismaService

--- a/src/libs/db/base.model.ts
+++ b/src/libs/db/base.model.ts
@@ -1,5 +1,5 @@
 import { IdModel } from '@libs/db/id.model';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export interface BaseModelProps {
   id: AggregateID;

--- a/src/libs/db/id.model.ts
+++ b/src/libs/db/id.model.ts
@@ -1,4 +1,4 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export class IdModel {
   readonly id: AggregateID;

--- a/src/libs/ddd/aggregate-root.base.ts
+++ b/src/libs/ddd/aggregate-root.base.ts
@@ -1,7 +1,7 @@
 import { RequestContextService } from '@libs/application/context/app-request.context';
-import type { DomainEvent } from '@libs/ddd/base-domain.event';
+import { DomainEvent } from '@libs/ddd/base-domain.event';
 import { Entity } from '@libs/ddd/entity.base';
-import type { EventEmitter2 } from '@nestjs/event-emitter';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 export abstract class AggregateRoot<EntityProps> extends Entity<EntityProps> {
   _domainEvents: DomainEvent[] = [];

--- a/src/libs/ddd/aggregate.base.ts
+++ b/src/libs/ddd/aggregate.base.ts
@@ -1,4 +1,4 @@
-import type { Entity } from '@libs/ddd/entity.base';
+import { Entity } from '@libs/ddd/entity.base';
 import { convertPropsToObject } from '@libs/utils/util';
 
 type AggregateProps<T extends Entity<K>, K> = { [key: string]: T };

--- a/src/libs/ddd/base-domain.event.ts
+++ b/src/libs/ddd/base-domain.event.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import { RequestContextService } from '@libs/application/context/app-request.context';
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { Guard } from '@libs/guard';

--- a/src/libs/ddd/domain-exception.base.ts
+++ b/src/libs/ddd/domain-exception.base.ts
@@ -1,5 +1,5 @@
-import type { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
-import type { ValueOf } from '@libs/types/type';
+import { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
+import { ValueOf } from '@libs/types/type';
 
 export abstract class DomainException {
   abstract readonly code: ValueOf<typeof ERROR_CODE>;

--- a/src/libs/ddd/mapper.interface.ts
+++ b/src/libs/ddd/mapper.interface.ts
@@ -1,4 +1,4 @@
-import type { Entity } from './entity.base';
+import { Entity } from './entity.base';
 
 export interface Mapper<
   DomainEntity extends Entity<unknown>,

--- a/src/libs/ddd/query.base.ts
+++ b/src/libs/ddd/query.base.ts
@@ -1,7 +1,7 @@
 import { SortOrder } from '@libs/api/types/api.constant';
-import type { CursorBy, OrderBy } from '@libs/api/types/api.type';
-import type { BaseModel } from '@libs/db/base.schema';
-import type { PaginatedQueryParams } from '@libs/types/type';
+import { CursorBy, OrderBy } from '@libs/api/types/api.type';
+import { BaseModel } from '@libs/db/base.schema';
+import { PaginatedQueryParams } from '@libs/types/type';
 
 /**
  * Base class for regular queries

--- a/src/libs/ddd/repository.port.ts
+++ b/src/libs/ddd/repository.port.ts
@@ -5,7 +5,7 @@
     in a respective repository.
 */
 
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export interface RepositoryPort<Entity, Include = unknown> {
   create(entity: Entity): Promise<void>;

--- a/src/libs/email/services/email.service-port.ts
+++ b/src/libs/email/services/email.service-port.ts
@@ -1,4 +1,4 @@
-import type { AggregateID } from '@libs/ddd/entity.base';
+import { AggregateID } from '@libs/ddd/entity.base';
 
 export interface EmailServicePort {
   sendVerificationEmail(

--- a/src/libs/email/services/email.service.ts
+++ b/src/libs/email/services/email.service.ts
@@ -1,13 +1,13 @@
 import { routesV1 } from '@config/app.route';
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
-import type { AggregateID } from '@libs/ddd/entity.base';
-import type { EmailServicePort } from '@libs/email/services/email.service-port';
+import { Key } from '@libs/core/app-config/types/app-config.type';
+import { AggregateID } from '@libs/ddd/entity.base';
+import { EmailServicePort } from '@libs/email/services/email.service-port';
 import { Inject, Injectable } from '@nestjs/common';
 import nodemailer from 'nodemailer';
-import type Mail from 'nodemailer/lib/mailer';
+import Mail from 'nodemailer/lib/mailer';
 
 @Injectable()
 export class EmailService implements EmailServicePort {

--- a/src/libs/exceptions/client-errors/exceptions/http-bad-request.exception.ts
+++ b/src/libs/exceptions/client-errors/exceptions/http-bad-request.exception.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 
 import { HttpException } from '@libs/exceptions/http.exception';
-import type { HttpError } from '@libs/exceptions/types/exceptions.type';
+import { HttpError } from '@libs/exceptions/types/exceptions.type';
 
 /**
  * status code 400 error exception

--- a/src/libs/exceptions/client-errors/exceptions/http-conflict.exception.ts
+++ b/src/libs/exceptions/client-errors/exceptions/http-conflict.exception.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 
 import { HttpException } from '@libs/exceptions/http.exception';
-import type { HttpError } from '@libs/exceptions/types/exceptions.type';
+import { HttpError } from '@libs/exceptions/types/exceptions.type';
 
 /**
  * status code 409 error exception

--- a/src/libs/exceptions/client-errors/exceptions/http-forbidden.exception.ts
+++ b/src/libs/exceptions/client-errors/exceptions/http-forbidden.exception.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 
 import { HttpException } from '@libs/exceptions/http.exception';
-import type { HttpError } from '@libs/exceptions/types/exceptions.type';
+import { HttpError } from '@libs/exceptions/types/exceptions.type';
 
 /**
  * status code 403 error exception

--- a/src/libs/exceptions/client-errors/exceptions/http-not-found.exception.ts
+++ b/src/libs/exceptions/client-errors/exceptions/http-not-found.exception.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 
 import { HttpException } from '@libs/exceptions/http.exception';
-import type { HttpError } from '@libs/exceptions/types/exceptions.type';
+import { HttpError } from '@libs/exceptions/types/exceptions.type';
 
 /**
  * status code 404 error exception

--- a/src/libs/exceptions/client-errors/exceptions/http-unauthorized.exception.ts
+++ b/src/libs/exceptions/client-errors/exceptions/http-unauthorized.exception.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 
 import { HttpException } from '@libs/exceptions/http.exception';
-import type { HttpError } from '@libs/exceptions/types/exceptions.type';
+import { HttpError } from '@libs/exceptions/types/exceptions.type';
 /**
  * status code 401 error exception
  */

--- a/src/libs/exceptions/client-errors/exceptions/http-unprocessable-entity.exception.ts
+++ b/src/libs/exceptions/client-errors/exceptions/http-unprocessable-entity.exception.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 
 import { HttpException } from '@libs/exceptions/http.exception';
-import type { HttpError } from '@libs/exceptions/types/exceptions.type';
+import { HttpError } from '@libs/exceptions/types/exceptions.type';
 /**
  * status code 422 error exception
  */

--- a/src/libs/exceptions/client-errors/filters/bad-request.exception-filter.ts
+++ b/src/libs/exceptions/client-errors/filters/bad-request.exception-filter.ts
@@ -1,5 +1,5 @@
 import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptions/http-bad-request.exception';
-import type { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
+import { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import {
   type ArgumentsHost,
@@ -8,7 +8,7 @@ import {
   type ExceptionFilter,
   HttpStatus,
 } from '@nestjs/common';
-import type { Response } from 'express';
+import { Response } from 'express';
 
 @Catch(BadRequestException)
 export class BadRequestExceptionFilter implements ExceptionFilter {

--- a/src/libs/exceptions/client-errors/filters/bad-request.exception-filter.ts
+++ b/src/libs/exceptions/client-errors/filters/bad-request.exception-filter.ts
@@ -2,10 +2,10 @@ import { HttpBadRequestException } from '@libs/exceptions/client-errors/exceptio
 import { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import {
-  type ArgumentsHost,
+  ArgumentsHost,
   BadRequestException,
   Catch,
-  type ExceptionFilter,
+  ExceptionFilter,
   HttpStatus,
 } from '@nestjs/common';
 import { Response } from 'express';

--- a/src/libs/exceptions/client-errors/filters/http-client-error.exception-filter.ts
+++ b/src/libs/exceptions/client-errors/filters/http-client-error.exception-filter.ts
@@ -3,7 +3,7 @@ import { HttpConflictException } from '@libs/exceptions/client-errors/exceptions
 import { HttpForbiddenException } from '@libs/exceptions/client-errors/exceptions/http-forbidden.exception';
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';
-import type { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
+import { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
 import {
   type ArgumentsHost,
   Catch,
@@ -11,7 +11,7 @@ import {
 } from '@nestjs/common';
 
 import { HttpUnprocessableEntityException } from '@libs/exceptions/client-errors/exceptions/http-unprocessable-entity.exception';
-import type { Response } from 'express';
+import { Response } from 'express';
 
 type ClientErrorException =
   | HttpBadRequestException

--- a/src/libs/exceptions/client-errors/filters/http-client-error.exception-filter.ts
+++ b/src/libs/exceptions/client-errors/filters/http-client-error.exception-filter.ts
@@ -4,11 +4,7 @@ import { HttpForbiddenException } from '@libs/exceptions/client-errors/exception
 import { HttpNotFoundException } from '@libs/exceptions/client-errors/exceptions/http-not-found.exception';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';
 import { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
-import {
-  type ArgumentsHost,
-  Catch,
-  type ExceptionFilter,
-} from '@nestjs/common';
+import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
 
 import { HttpUnprocessableEntityException } from '@libs/exceptions/client-errors/exceptions/http-unprocessable-entity.exception';
 import { Response } from 'express';

--- a/src/libs/exceptions/dtos/exception-response.dto.ts
+++ b/src/libs/exceptions/dtos/exception-response.dto.ts
@@ -1,7 +1,7 @@
-import type { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
-import type { ERROR_MESSAGE } from '@libs/exceptions/types/errors/error-message.constant';
-import type { ValueOf } from '@libs/types/type';
-import type { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
+import { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
+import { ERROR_MESSAGE } from '@libs/exceptions/types/errors/error-message.constant';
+import { ValueOf } from '@libs/types/type';
+import { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
 
 export class ExceptionResponseDto {
   public readonly timestamp: Date;

--- a/src/libs/exceptions/etc-errors/filters/http-path-not-found.exception-filter.ts
+++ b/src/libs/exceptions/etc-errors/filters/http-path-not-found.exception-filter.ts
@@ -5,9 +5,9 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 
-import type { Response } from 'express';
+import { Response } from 'express';
 
-import type { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
+import { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 
 /**

--- a/src/libs/exceptions/etc-errors/filters/http-path-not-found.exception-filter.ts
+++ b/src/libs/exceptions/etc-errors/filters/http-path-not-found.exception-filter.ts
@@ -1,7 +1,7 @@
 import {
-  type ArgumentsHost,
+  ArgumentsHost,
   Catch,
-  type ExceptionFilter,
+  ExceptionFilter,
   NotFoundException,
 } from '@nestjs/common';
 

--- a/src/libs/exceptions/http.exception.ts
+++ b/src/libs/exceptions/http.exception.ts
@@ -6,16 +6,16 @@ import {
   type Type,
   applyDecorators,
 } from '@nestjs/common';
-import type { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
+import { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
 import { ApiExtraModels, ApiResponse, getSchemaPath } from '@nestjs/swagger';
-import type {
+import {
   ExampleObject,
   ReferenceObject,
   SchemaObject,
 } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
 
-import type { HttpError } from '@libs/exceptions/types/exceptions.type';
-import type { ValueOf } from '@libs/types/type';
+import { HttpError } from '@libs/exceptions/types/exceptions.type';
+import { ValueOf } from '@libs/types/type';
 
 export class HttpException extends NestHttpException {
   public readonly statusCode: ErrorHttpStatusCode;

--- a/src/libs/exceptions/http.exception.ts
+++ b/src/libs/exceptions/http.exception.ts
@@ -3,7 +3,7 @@ import { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
 import { ERROR_MESSAGE } from '@libs/exceptions/types/errors/error-message.constant';
 import {
   HttpException as NestHttpException,
-  type Type,
+  Type,
   applyDecorators,
 } from '@nestjs/common';
 import { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';

--- a/src/libs/exceptions/server-errors/exceptions/http-internal-server-error.exception.ts
+++ b/src/libs/exceptions/server-errors/exceptions/http-internal-server-error.exception.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 
 import { HttpException } from '@libs/exceptions/http.exception';
-import type { HttpError } from '@libs/exceptions/types/exceptions.type';
+import { HttpError } from '@libs/exceptions/types/exceptions.type';
 
 /**
  * customize status code 500 error exception

--- a/src/libs/exceptions/server-errors/exceptions/http-process-error.exception.ts
+++ b/src/libs/exceptions/server-errors/exceptions/http-process-error.exception.ts
@@ -1,6 +1,6 @@
-import type { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
+import { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
 import { HttpStatus } from '@nestjs/common';
-import type { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
+import { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
 
 /**
  * node  process error exception

--- a/src/libs/exceptions/server-errors/filters/http-internal-server-error.exception-filter.ts
+++ b/src/libs/exceptions/server-errors/filters/http-internal-server-error.exception-filter.ts
@@ -1,8 +1,4 @@
-import {
-  type ArgumentsHost,
-  Catch,
-  type ExceptionFilter,
-} from '@nestjs/common';
+import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
 import { Response } from 'express';
 
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';

--- a/src/libs/exceptions/server-errors/filters/http-internal-server-error.exception-filter.ts
+++ b/src/libs/exceptions/server-errors/filters/http-internal-server-error.exception-filter.ts
@@ -3,10 +3,10 @@ import {
   Catch,
   type ExceptionFilter,
 } from '@nestjs/common';
-import type { Response } from 'express';
+import { Response } from 'express';
 
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
-import type { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
+import { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
 
 /**
  * nestJS 메서드를 이용한 500번 에러 를 잡는 exception filter

--- a/src/libs/exceptions/server-errors/filters/http-process-error.exception-filter.ts
+++ b/src/libs/exceptions/server-errors/filters/http-process-error.exception-filter.ts
@@ -1,7 +1,7 @@
 import {
-  type ArgumentsHost,
+  ArgumentsHost,
   Catch,
-  type ExceptionFilter,
+  ExceptionFilter,
   HttpStatus,
 } from '@nestjs/common';
 

--- a/src/libs/exceptions/server-errors/filters/http-process-error.exception-filter.ts
+++ b/src/libs/exceptions/server-errors/filters/http-process-error.exception-filter.ts
@@ -5,10 +5,10 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 
-import type { Response } from 'express';
+import { Response } from 'express';
 
 import { HttpProcessErrorException } from '@libs/exceptions/server-errors/exceptions/http-process-error.exception';
-import type { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
+import { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 
 /**

--- a/src/libs/exceptions/server-errors/filters/http-remainder.exception-filter.ts
+++ b/src/libs/exceptions/server-errors/filters/http-remainder.exception-filter.ts
@@ -6,10 +6,10 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 
-import type { Response } from 'express';
+import { Response } from 'express';
 
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
-import type { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
+import { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 
 /**

--- a/src/libs/exceptions/server-errors/filters/http-remainder.exception-filter.ts
+++ b/src/libs/exceptions/server-errors/filters/http-remainder.exception-filter.ts
@@ -1,7 +1,7 @@
 import {
-  type ArgumentsHost,
+  ArgumentsHost,
   Catch,
-  type ExceptionFilter,
+  ExceptionFilter,
   HttpException,
   HttpStatus,
 } from '@nestjs/common';

--- a/src/libs/exceptions/server-errors/filters/zod-error.exception-filter.ts
+++ b/src/libs/exceptions/server-errors/filters/zod-error.exception-filter.ts
@@ -8,9 +8,9 @@ import {
 } from '@nestjs/common';
 
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
-import type { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
+import { HttpExceptionService } from '@libs/exceptions/services/http-exception.service';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
-import type { Request, Response } from 'express';
+import { Request, Response } from 'express';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ZodError } from 'zod';
 

--- a/src/libs/exceptions/server-errors/filters/zod-error.exception-filter.ts
+++ b/src/libs/exceptions/server-errors/filters/zod-error.exception-filter.ts
@@ -1,10 +1,10 @@
 import {
-  type ArgumentsHost,
+  ArgumentsHost,
   Catch,
-  type ExceptionFilter,
+  ExceptionFilter,
   HttpStatus,
   Inject,
-  type Logger,
+  Logger,
 } from '@nestjs/common';
 
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';

--- a/src/libs/exceptions/services/http-exception.service.ts
+++ b/src/libs/exceptions/services/http-exception.service.ts
@@ -1,5 +1,5 @@
 import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
-import { Inject, Injectable, type Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
 import { Key } from '@libs/core/app-config/types/app-config.type';

--- a/src/libs/exceptions/services/http-exception.service.ts
+++ b/src/libs/exceptions/services/http-exception.service.ts
@@ -1,12 +1,12 @@
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { Inject, Injectable, type Logger } from '@nestjs/common';
 
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
+import { Key } from '@libs/core/app-config/types/app-config.type';
 import { ExceptionResponseDto } from '@libs/exceptions/dtos/exception-response.dto';
-import type { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
+import { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
 import { ERROR_MESSAGE } from '@libs/exceptions/types/errors/error-message.constant';
-import type { ValueOf } from '@libs/types/type';
+import { ValueOf } from '@libs/types/type';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 interface ExceptionError {

--- a/src/libs/exceptions/socket/filters/socket-catch-http.exception-filter.ts
+++ b/src/libs/exceptions/socket/filters/socket-catch-http.exception-filter.ts
@@ -1,5 +1,5 @@
 import { HttpException } from '@libs/exceptions/http.exception';
-import { type ArgumentsHost, Catch } from '@nestjs/common';
+import { ArgumentsHost, Catch } from '@nestjs/common';
 import { BaseWsExceptionFilter } from '@nestjs/websockets';
 
 @Catch(HttpException)

--- a/src/libs/exceptions/types/errors/auth/auth-error-message.constant.ts
+++ b/src/libs/exceptions/types/errors/auth/auth-error-message.constant.ts
@@ -1,5 +1,5 @@
 import { AUTH_ERROR_CODE } from '@libs/exceptions/types/errors/auth/auth-error-code.constant';
-import type { ErrorMessage } from '@libs/types/type';
+import { ErrorMessage } from '@libs/types/type';
 
 export const AUTH_ERROR_MESSAGE: ErrorMessage<typeof AUTH_ERROR_CODE> = {
   [AUTH_ERROR_CODE.WRONG_EMAIL_OR_PASSWORD]:

--- a/src/libs/exceptions/types/errors/blog/blog-error-message.constant.ts
+++ b/src/libs/exceptions/types/errors/blog/blog-error-message.constant.ts
@@ -1,5 +1,5 @@
 import { BLOG_ERROR_CODE } from '@libs/exceptions/types/errors/blog/blog-error-code.constant';
-import type { ErrorMessage } from '@libs/types/type';
+import { ErrorMessage } from '@libs/types/type';
 
 export const BLOG_ERROR_MESSAGE: ErrorMessage<typeof BLOG_ERROR_CODE> = {
   [BLOG_ERROR_CODE.YOU_ALREADY_HAVE_A_BLOG]: 'You already have a blog',

--- a/src/libs/exceptions/types/errors/chat-room/chat-room-error-message.constant.ts
+++ b/src/libs/exceptions/types/errors/chat-room/chat-room-error-message.constant.ts
@@ -1,5 +1,5 @@
 import { CHAT_ROOM_ERROR_CODE } from '@libs/exceptions/types/errors/chat-room/chat-room-error-code.constant';
-import type { ErrorMessage } from '@libs/types/type';
+import { ErrorMessage } from '@libs/types/type';
 
 export const CHAT_ROOM_ERROR_MESSAGE: ErrorMessage<
   typeof CHAT_ROOM_ERROR_CODE

--- a/src/libs/exceptions/types/errors/common/common-error-message.constant.ts
+++ b/src/libs/exceptions/types/errors/common/common-error-message.constant.ts
@@ -1,5 +1,5 @@
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
-import type { ErrorMessage } from '@libs/types/type';
+import { ErrorMessage } from '@libs/types/type';
 
 export const COMMON_ERROR_MESSAGE: ErrorMessage<typeof COMMON_ERROR_CODE> = {
   [COMMON_ERROR_CODE.SERVER_ERROR]:

--- a/src/libs/exceptions/types/errors/user-connection/user-connection-error-message.constant.ts
+++ b/src/libs/exceptions/types/errors/user-connection/user-connection-error-message.constant.ts
@@ -1,5 +1,5 @@
 import { USER_CONNECTION_ERROR_CODE } from '@libs/exceptions/types/errors/user-connection/user-connection-error-code.constant';
-import type { ErrorMessage } from '@libs/types/type';
+import { ErrorMessage } from '@libs/types/type';
 
 export const USER_CONNECTION_ERROR_MESSAGE: ErrorMessage<
   typeof USER_CONNECTION_ERROR_CODE

--- a/src/libs/exceptions/types/errors/user/user-error-message.constant.ts
+++ b/src/libs/exceptions/types/errors/user/user-error-message.constant.ts
@@ -1,5 +1,5 @@
 import { USER_ERROR_CODE } from '@libs/exceptions/types/errors/user/user-error-code.constant';
-import type { ErrorMessage } from '@libs/types/type';
+import { ErrorMessage } from '@libs/types/type';
 
 export const USER_ERROR_MESSAGE: ErrorMessage<typeof USER_ERROR_CODE> = {
   [USER_ERROR_CODE.ALREADY_CREATED_USER]: "You're already signed up.",

--- a/src/libs/exceptions/types/exceptions.type.ts
+++ b/src/libs/exceptions/types/exceptions.type.ts
@@ -1,4 +1,4 @@
-import type { HttpException } from '@libs/exceptions/http.exception';
+import { HttpException } from '@libs/exceptions/http.exception';
 
 export type HttpError<E extends HttpException> = Pick<
   E,

--- a/src/libs/guards/decorators/set-guard-type.decorator.ts
+++ b/src/libs/guards/decorators/set-guard-type.decorator.ts
@@ -1,5 +1,5 @@
 import { GUARD_TYPE_TOKEN } from '@libs/guards/types/guard.constant';
-import type { GuardTypeUnion } from '@libs/guards/types/guard.type';
+import { GuardTypeUnion } from '@libs/guards/types/guard.type';
 import { SetMetadata } from '@nestjs/common';
 
 export const SetGuardType = (

--- a/src/libs/guards/guard.module.ts
+++ b/src/libs/guards/guard.module.ts
@@ -2,7 +2,7 @@ import { BasicTokenGuard } from '@libs/guards/providers/basic-auth.guard';
 import { JwtAccessTokenAuthGuard } from '@libs/guards/providers/jwt-access-token-auth.guard';
 import { JwtBearerAuthStrategy } from '@libs/guards/providers/jwt-bearer-auth.strategy';
 import { JwtRefreshTokenAuthGuard } from '@libs/guards/providers/jwt-refresh-token-auth.guard';
-import { Module, type Provider } from '@nestjs/common';
+import { Module, Provider } from '@nestjs/common';
 
 const guards: Provider[] = [
   JwtAccessTokenAuthGuard,

--- a/src/libs/guards/providers/basic-auth.guard.ts
+++ b/src/libs/guards/providers/basic-auth.guard.ts
@@ -5,7 +5,7 @@ import {
   type ExecutionContext,
   Injectable,
 } from '@nestjs/common';
-import type { Request } from 'express';
+import { Request } from 'express';
 
 @Injectable()
 export class BasicTokenGuard implements CanActivate {

--- a/src/libs/guards/providers/basic-auth.guard.ts
+++ b/src/libs/guards/providers/basic-auth.guard.ts
@@ -1,10 +1,6 @@
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
-import {
-  type CanActivate,
-  type ExecutionContext,
-  Injectable,
-} from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Request } from 'express';
 
 @Injectable()

--- a/src/libs/guards/providers/jwt-access-token-auth.guard.ts
+++ b/src/libs/guards/providers/jwt-access-token-auth.guard.ts
@@ -2,11 +2,11 @@ import { TokenType } from '@libs/app-jwt/types/app-jwt.enum';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { GUARD_TYPE_TOKEN, GuardType } from '@libs/guards/types/guard.constant';
-import type { GuardTypeUnion } from '@libs/guards/types/guard.type';
+import { GuardTypeUnion } from '@libs/guards/types/guard.type';
 import { type ExecutionContext, Injectable } from '@nestjs/common';
-import type { Reflector } from '@nestjs/core';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
-import type { Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 
 @Injectable()
 export class JwtAccessTokenAuthGuard extends AuthGuard('jwt') {

--- a/src/libs/guards/providers/jwt-access-token-auth.guard.ts
+++ b/src/libs/guards/providers/jwt-access-token-auth.guard.ts
@@ -3,7 +3,7 @@ import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/except
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { GUARD_TYPE_TOKEN, GuardType } from '@libs/guards/types/guard.constant';
 import { GuardTypeUnion } from '@libs/guards/types/guard.type';
-import { type ExecutionContext, Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { Observable } from 'rxjs';

--- a/src/libs/guards/providers/jwt-bearer-auth.strategy.ts
+++ b/src/libs/guards/providers/jwt-bearer-auth.strategy.ts
@@ -1,8 +1,8 @@
-import type { JwtPayload } from '@libs/app-jwt/types/app-jwt.interface';
+import { JwtPayload } from '@libs/app-jwt/types/app-jwt.interface';
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
+import { Key } from '@libs/core/app-config/types/app-config.type';
 import { Inject, Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';

--- a/src/libs/guards/providers/jwt-refresh-token-auth.guard.ts
+++ b/src/libs/guards/providers/jwt-refresh-token-auth.guard.ts
@@ -2,7 +2,7 @@ import { TokenType } from '@libs/app-jwt/types/app-jwt.enum';
 import { HttpUnauthorizedException } from '@libs/exceptions/client-errors/exceptions/http-unauthorized.exception';
 import { COMMON_ERROR_CODE } from '@libs/exceptions/types/errors/common/common-error-code.constant';
 import { Injectable } from '@nestjs/common';
-import type { Reflector } from '@nestjs/core';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()

--- a/src/libs/guards/types/guard.type.ts
+++ b/src/libs/guards/types/guard.type.ts
@@ -1,4 +1,4 @@
-import type { GuardType } from '@libs/guards/types/guard.constant';
-import type { ValueOf } from '@libs/types/type';
+import { GuardType } from '@libs/guards/types/guard.constant';
+import { ValueOf } from '@libs/types/type';
 
 export type GuardTypeUnion = ValueOf<typeof GuardType>;

--- a/src/libs/interceptors/context/context.interceptor.ts
+++ b/src/libs/interceptors/context/context.interceptor.ts
@@ -1,12 +1,12 @@
 import {
-  type CallHandler,
-  type ExecutionContext,
+  CallHandler,
+  ExecutionContext,
   Injectable,
-  type NestInterceptor,
+  NestInterceptor,
 } from '@nestjs/common';
 import { nanoid } from 'nanoid';
 
-import { type Observable, tap } from 'rxjs';
+import { Observable, tap } from 'rxjs';
 import { RequestContextService } from 'src/libs/application/context/app-request.context';
 
 @Injectable()

--- a/src/libs/interceptors/logging/request-response-logging.interceptor.ts
+++ b/src/libs/interceptors/logging/request-response-logging.interceptor.ts
@@ -5,9 +5,9 @@ import {
   Logger,
   type NestInterceptor,
 } from '@nestjs/common';
-import type { Request, Response } from 'express';
+import { Request, Response } from 'express';
 
-import type { Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 @Injectable()

--- a/src/libs/interceptors/logging/request-response-logging.interceptor.ts
+++ b/src/libs/interceptors/logging/request-response-logging.interceptor.ts
@@ -1,9 +1,9 @@
 import {
-  type CallHandler,
-  type ExecutionContext,
+  CallHandler,
+  ExecutionContext,
   Injectable,
   Logger,
-  type NestInterceptor,
+  NestInterceptor,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 

--- a/src/libs/interceptors/pagination/builders/pagination-interceptor-response.builder.spec.ts
+++ b/src/libs/interceptors/pagination/builders/pagination-interceptor-response.builder.spec.ts
@@ -2,7 +2,7 @@ import { OffsetPaginationQueryDto } from '@libs/api/dtos/offset-pagination-query
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { PaginationResponseBuilder } from '@libs/interceptors/pagination/builders/pagination-interceptor-response.builder';
 import { OffsetPaginationResponseDto } from '@libs/interceptors/pagination/dtos/pagination-interceptor-response.dto';
-import { Test, type TestingModule } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
 
 describe(PaginationResponseBuilder.name, () => {
   let builder: PaginationResponseBuilder;

--- a/src/libs/interceptors/pagination/builders/pagination-interceptor-response.builder.ts
+++ b/src/libs/interceptors/pagination/builders/pagination-interceptor-response.builder.ts
@@ -1,7 +1,7 @@
-import type { OffsetPaginationRequestQueryDto } from '@libs/api/dtos/request/offset-pagination.request-query-dto';
+import { OffsetPaginationRequestQueryDto } from '@libs/api/dtos/request/offset-pagination.request-query-dto';
 import { PageLimit } from '@libs/api/types/api.constant';
-import type { CursorBy } from '@libs/api/types/api.type';
-import type { BaseModel } from '@libs/db/base.schema';
+import { CursorBy } from '@libs/api/types/api.type';
+import { BaseModel } from '@libs/db/base.schema';
 import { HttpInternalServerErrorException } from '@libs/exceptions/server-errors/exceptions/http-internal-server-error.exception';
 import { ERROR_CODE } from '@libs/exceptions/types/errors/error-code.constant';
 import { CursorPaginationResponseDto } from '@libs/interceptors/pagination/dtos/cursor-pagination-interceptor.response-dto';

--- a/src/libs/interceptors/pagination/dtos/cursor-pagination-interceptor.response-dto.ts
+++ b/src/libs/interceptors/pagination/dtos/cursor-pagination-interceptor.response-dto.ts
@@ -1,7 +1,7 @@
-import type { CursorBy } from '@libs/api/types/api.type';
-import type { BaseModel } from '@libs/db/base.schema';
+import { CursorBy } from '@libs/api/types/api.type';
+import { BaseModel } from '@libs/db/base.schema';
 import { type HttpStatus, type Type, applyDecorators } from '@nestjs/common';
-import type { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
+import { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
 import {
   ApiExtraModels,
   ApiProperty,

--- a/src/libs/interceptors/pagination/dtos/cursor-pagination-interceptor.response-dto.ts
+++ b/src/libs/interceptors/pagination/dtos/cursor-pagination-interceptor.response-dto.ts
@@ -1,11 +1,11 @@
 import { CursorBy } from '@libs/api/types/api.type';
 import { BaseModel } from '@libs/db/base.schema';
-import { type HttpStatus, type Type, applyDecorators } from '@nestjs/common';
+import { HttpStatus, Type, applyDecorators } from '@nestjs/common';
 import { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
 import {
   ApiExtraModels,
   ApiProperty,
-  type ApiPropertyOptions,
+  ApiPropertyOptions,
   ApiResponse,
 } from '@nestjs/swagger';
 

--- a/src/libs/interceptors/pagination/dtos/offset-pagination-interceptor.response-dto.ts
+++ b/src/libs/interceptors/pagination/dtos/offset-pagination-interceptor.response-dto.ts
@@ -1,9 +1,9 @@
-import { type HttpStatus, type Type, applyDecorators } from '@nestjs/common';
+import { HttpStatus, Type, applyDecorators } from '@nestjs/common';
 import { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
 import {
   ApiExtraModels,
   ApiProperty,
-  type ApiPropertyOptions,
+  ApiPropertyOptions,
   ApiResponse,
 } from '@nestjs/swagger';
 

--- a/src/libs/interceptors/pagination/dtos/offset-pagination-interceptor.response-dto.ts
+++ b/src/libs/interceptors/pagination/dtos/offset-pagination-interceptor.response-dto.ts
@@ -1,5 +1,5 @@
 import { type HttpStatus, type Type, applyDecorators } from '@nestjs/common';
-import type { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
+import { ErrorHttpStatusCode } from '@nestjs/common/utils/http-error-by-code.util';
 import {
   ApiExtraModels,
   ApiProperty,

--- a/src/libs/interceptors/pagination/pagination.interceptor.ts
+++ b/src/libs/interceptors/pagination/pagination.interceptor.ts
@@ -3,10 +3,10 @@ import { BaseModel } from '@libs/db/base.schema';
 import { PaginationResponseBuilder } from '@libs/interceptors/pagination/builders/pagination-interceptor-response.builder';
 import { SET_PAGINATION } from '@libs/interceptors/pagination/types/pagination-interceptor.constant';
 import {
-  type CallHandler,
-  type ExecutionContext,
+  CallHandler,
+  ExecutionContext,
   Injectable,
-  type NestInterceptor,
+  NestInterceptor,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 

--- a/src/libs/interceptors/pagination/pagination.interceptor.ts
+++ b/src/libs/interceptors/pagination/pagination.interceptor.ts
@@ -1,6 +1,6 @@
-import type { OffsetPaginationRequestQueryDto } from '@libs/api/dtos/request/offset-pagination.request-query-dto';
-import type { BaseModel } from '@libs/db/base.schema';
-import type { PaginationResponseBuilder } from '@libs/interceptors/pagination/builders/pagination-interceptor-response.builder';
+import { OffsetPaginationRequestQueryDto } from '@libs/api/dtos/request/offset-pagination.request-query-dto';
+import { BaseModel } from '@libs/db/base.schema';
+import { PaginationResponseBuilder } from '@libs/interceptors/pagination/builders/pagination-interceptor-response.builder';
 import { SET_PAGINATION } from '@libs/interceptors/pagination/types/pagination-interceptor.constant';
 import {
   type CallHandler,
@@ -8,12 +8,12 @@ import {
   Injectable,
   type NestInterceptor,
 } from '@nestjs/common';
-import type { Reflector } from '@nestjs/core';
+import { Reflector } from '@nestjs/core';
 
-import type { PaginationInterceptorArgs } from '@libs/interceptors/pagination/types/pagination-interceptor.type';
+import { PaginationInterceptorArgs } from '@libs/interceptors/pagination/types/pagination-interceptor.type';
 import { isNil } from '@libs/utils/util';
 
-import type { Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 @Injectable()

--- a/src/libs/interceptors/pagination/types/pagination-interceptor.type.ts
+++ b/src/libs/interceptors/pagination/types/pagination-interceptor.type.ts
@@ -1,4 +1,4 @@
-import type { PaginationBy } from '@libs/interceptors/pagination/types/pagination-interceptor.enum';
+import { PaginationBy } from '@libs/interceptors/pagination/types/pagination-interceptor.enum';
 
 export type PaginationInterceptorArgs =
   | PaginationBy.Cursor

--- a/src/libs/logger/factories/winston-logger-options.factory.ts
+++ b/src/libs/logger/factories/winston-logger-options.factory.ts
@@ -1,7 +1,7 @@
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
+import { Key } from '@libs/core/app-config/types/app-config.type';
 import { Inject, Injectable } from '@nestjs/common';
 import {
   type WinstonModuleOptions,

--- a/src/libs/logger/factories/winston-logger-options.factory.ts
+++ b/src/libs/logger/factories/winston-logger-options.factory.ts
@@ -4,8 +4,8 @@ import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-co
 import { Key } from '@libs/core/app-config/types/app-config.type';
 import { Inject, Injectable } from '@nestjs/common';
 import {
-  type WinstonModuleOptions,
-  type WinstonModuleOptionsFactory,
+  WinstonModuleOptions,
+  WinstonModuleOptionsFactory,
   utilities,
 } from 'nest-winston';
 import winston from 'winston';

--- a/src/libs/middlewares/method-override.middleware.ts
+++ b/src/libs/middlewares/method-override.middleware.ts
@@ -1,4 +1,4 @@
-import { Injectable, type NestMiddleware } from '@nestjs/common';
+import { Injectable, NestMiddleware } from '@nestjs/common';
 
 import { NextFunction, Request, Response } from 'express';
 

--- a/src/libs/middlewares/method-override.middleware.ts
+++ b/src/libs/middlewares/method-override.middleware.ts
@@ -1,6 +1,6 @@
 import { Injectable, type NestMiddleware } from '@nestjs/common';
 
-import type { NextFunction, Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 
 const requestMethodsArray = [
   'GET',

--- a/src/libs/pipes/custom-validation.pipe.ts
+++ b/src/libs/pipes/custom-validation.pipe.ts
@@ -1,5 +1,5 @@
 import { REWRITE_VALIDATION_OPTIONS_TOKEN } from '@libs/pipes/types/rewrite-validation-options.token';
-import { type ArgumentMetadata, ValidationPipe } from '@nestjs/common';
+import { ArgumentMetadata, ValidationPipe } from '@nestjs/common';
 
 export class CustomValidationPipe extends ValidationPipe {
   async transform(value: any, metadata: ArgumentMetadata) {

--- a/src/libs/pipes/decorators/rewrite-validation-options.decorator.ts
+++ b/src/libs/pipes/decorators/rewrite-validation-options.decorator.ts
@@ -1,7 +1,7 @@
 import { REWRITE_VALIDATION_OPTIONS_TOKEN } from '@libs/pipes/types/rewrite-validation-options.token';
 import { SetMetadata } from '@nestjs/common';
 
-import type { ValidatorOptions } from 'class-validator';
+import { ValidatorOptions } from 'class-validator';
 
 export const RewriteValidationOptions = (
   validatorOptions: ValidatorOptions,

--- a/src/libs/s3/s3.module.ts
+++ b/src/libs/s3/s3.module.ts
@@ -3,9 +3,9 @@ import { Module } from '@nestjs/common';
 import { S3Client } from '@aws-sdk/client-s3';
 
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
+import { Key } from '@libs/core/app-config/types/app-config.type';
 import { S3Service } from '@libs/s3/services/s3.service';
 import { S3_CLIENT_TOKEN, S3_SERVICE_DI_TOKEN } from '@libs/s3/tokens/di.token';
 

--- a/src/libs/s3/services/s3.service.ts
+++ b/src/libs/s3/services/s3.service.ts
@@ -3,9 +3,9 @@ import { HttpStatus, Inject, Injectable, Logger } from '@nestjs/common';
 import {
   CopyObjectCommand,
   DeleteObjectsCommand,
-  type ObjectIdentifier,
+  ObjectIdentifier,
   PutObjectCommand,
-  type S3Client,
+  S3Client,
   S3ServiceException,
 } from '@aws-sdk/client-s3';
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';

--- a/src/libs/s3/services/s3.service.ts
+++ b/src/libs/s3/services/s3.service.ts
@@ -9,10 +9,10 @@ import {
   S3ServiceException,
 } from '@aws-sdk/client-s3';
 import { ENV_KEY } from '@libs/core/app-config/constants/app-config.constant';
-import type { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
+import { AppConfigServicePort } from '@libs/core/app-config/services/app-config.service-port';
 import { APP_CONFIG_SERVICE_DI_TOKEN } from '@libs/core/app-config/tokens/app-config.di-token';
-import type { Key } from '@libs/core/app-config/types/app-config.type';
-import type { S3ServicePort } from '@libs/s3/services/s3.service-port';
+import { Key } from '@libs/core/app-config/types/app-config.type';
+import { S3ServicePort } from '@libs/s3/services/s3.service-port';
 import { S3_CLIENT_TOKEN } from '@libs/s3/tokens/di.token';
 
 @Injectable()

--- a/src/libs/types/type.ts
+++ b/src/libs/types/type.ts
@@ -1,7 +1,7 @@
-import type { CursorBy, OrderBy } from '@libs/api/types/api.type';
-import type { BaseModel } from '@libs/db/base.schema';
-import type { ICommandHandler, IQueryHandler } from '@nestjs/cqrs';
-import type { ApiOperationOptions } from '@nestjs/swagger';
+import { CursorBy, OrderBy } from '@libs/api/types/api.type';
+import { BaseModel } from '@libs/db/base.schema';
+import { ICommandHandler, IQueryHandler } from '@nestjs/cqrs';
+import { ApiOperationOptions } from '@nestjs/swagger';
 
 export type ApiOperationOptionsWithSummary = Required<
   Pick<ApiOperationOptions, 'summary'>

--- a/src/libs/utils/util.ts
+++ b/src/libs/utils/util.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
 import { ValueObject } from '@libs/ddd/value-object.base';
-import type { Entity } from '../ddd/entity.base';
+import { Entity } from '../ddd/entity.base';
 
 const isEntity = (obj: unknown): obj is Entity<unknown> => {
   /**

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,4 +1,4 @@
-import type { INestApplication } from '@nestjs/common';
+import { INestApplication } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#203 

<!-- 내용 (필수) -->

### Description

biome lint rule에서 useImportType 옵션을 비활성화 했습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer
biome에서 기본으로 useImportType 옵션이 활성화되어 있는데요.
import 한 후 타입으로만 사용할 때 import type를 써서 js로 컴파일 할 때 로드되지 않도록 해서 최적화하는 규칙입니다.

그런데 nestjs에서 데코레이터와 타입을 사용해서 의존성을 주입하고 있기 때문에 타입으로 보이더라도 런타임 과정에서 값으로 참조하기 때문에 필요하게 되는데요. biome에서는 아직 이런 인식하지 못해서 import 를 import type으로 바꾸라고 하지만 실제로 해당 규칙을 따르게 되면 의존성 주입이 되지 않아 에러가 발생합니다..

biome 공식 문서에서도 DI가 올바르게 이루어지도록 useImportType을 비활성화 하는 방법을 추천하고 있어서 저희 프로젝트에서도 비활성화 하는게 좋을거 같아서 수정합니다.

++ 로컬 환경에서 정상 동작 되는거 확인했습니다.

<img width="757" alt="스크린샷 2025-04-18 오후 9 40 03" src="https://github.com/user-attachments/assets/bb88a0f7-d4b2-47e2-b3ab-40df13908267" />

<!-- 참고한 레퍼런스 링크 (선택) -->

### Reference Link
https://biomejs.dev/linter/rules/use-import-type/
