### PR TITLE
biome noGlobalIsFinite 룰 비활성화

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -49,7 +49,8 @@
         "noExplicitAny": "off",
         "noExtraNonNullAssertion": "error",
         "noMisleadingInstantiator": "error",
-        "noUnsafeDeclarationMerging": "error"
+        "noUnsafeDeclarationMerging": "error",
+        "noGlobalIsFinite": "off"
       }
     },
     "ignore": ["**/.eslintrc.js"]

--- a/src/libs/api/pipes/parse-positive-int.pipe.ts
+++ b/src/libs/api/pipes/parse-positive-int.pipe.ts
@@ -45,7 +45,7 @@ export class ParsePositiveBigIntPipe
     return (
       ['string', 'number'].includes(typeof value) &&
       /^-?\d+$/.test(value) &&
-      Number.isFinite(value as any) &&
+      isFinite(value as any) &&
       Number(value) >= 1
     );
   }


### PR DESCRIPTION
<!-- 이슈 넘버 url -->

### Issue Number

#208 

<!-- 내용 (필수) -->

### Description
biome linter에 noGlobalIsFinite 룰을 비활성화했습니다.
<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer
이전에 linter를 biome으로 변경할 때 noGlobalIsFinite 룰이 활성화되어 있어서 `ParsePositiveBigIntPipe` 내에 있는 `isFinite()` 함수를 `Number.isFinite()` 로 수정했었는데요. `isFinite()` 함수는 인자값을 강제로 Number로 변환해서 유한한 값인지 판단하는 반면에 `Number.isFinite()` 함수는 인자값을 Number로 변환하지 않아서 (인자값이 string 이여서) 이 부분에서 계속 False가 뜨고 있었습니다.

이 룰이 현재 프로젝트에서는 필요 없을거 같아서 비활성화 했고, `isFinite()` 함수로 다시 되돌렸습니다.
